### PR TITLE
many and varied send_and_confirm experiments (NO MERGE EXPECTED)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ore-cli"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "bincode",
  "bs58 0.5.1",
@@ -2436,8 +2436,10 @@ dependencies = [
  "ore-program",
  "solana-cli-config",
  "solana-client",
+ "solana-connection-cache",
  "solana-program",
  "solana-sdk",
+ "solana-tpu-client",
  "solana-transaction-status",
  "spl-associated-token-account",
  "spl-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,6 +2438,7 @@ dependencies = [
  "solana-client",
  "solana-connection-cache",
  "solana-program",
+ "solana-quic-client",
  "solana-sdk",
  "solana-tpu-client",
  "solana-transaction-status",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,6 +2442,7 @@ dependencies = [
  "solana-sdk",
  "solana-tpu-client",
  "solana-transaction-status",
+ "solana-udp-client",
  "spl-associated-token-account",
  "spl-token",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ solana-client = "^1.16"
 solana-connection-cache = "1.18.5"
 solana-program = "^1.16"
 solana-sdk = "^1.16"
-solana-tpu-client = "^1.16"
+solana-tpu-client = { version = "^1.16", features = ["spinner"] }
 solana-transaction-status = "^1.16"
 spl-associated-token-account = { version = "^2.2", features = [ "no-entrypoint" ] }
 spl-token = { version = "^4", features = ["no-entrypoint"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ solana-cli-config = "1.18.5"
 solana-client = "^1.16"
 solana-connection-cache = "1.18.5"
 solana-program = "^1.16"
+solana-quic-client = "^1.16"
 solana-sdk = "^1.16"
 solana-tpu-client = { version = "^1.16", features = ["spinner"] }
 solana-transaction-status = "^1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ore-cli"
-version = "0.3.4"
+version = "0.4.0"
 description = "A command line interface for the Ore program."
 license = "Apache-2.0"
 edition = "2021"
@@ -24,9 +24,14 @@ log = "0.4"
 ore = { version = "1.2.0", package = "ore-program" }
 solana-cli-config = "1.18.5"
 solana-client = "^1.16"
+solana-connection-cache = "1.18.5"
 solana-program = "^1.16"
 solana-sdk = "^1.16"
+solana-tpu-client = "^1.16"
 solana-transaction-status = "^1.16"
-spl-token = { version = "^4", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "^2.2", features = [ "no-entrypoint" ] }
+spl-token = { version = "^4", features = ["no-entrypoint"] }
 tokio = "1.35.1"
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ solana-quic-client = "^1.16"
 solana-sdk = "^1.16"
 solana-tpu-client = { version = "^1.16", features = ["spinner"] }
 solana-transaction-status = "^1.16"
+solana-udp-client = "^1.16"
 spl-associated-token-account = { version = "^2.2", features = [ "no-entrypoint" ] }
 spl-token = { version = "^4", features = ["no-entrypoint"] }
 tokio = "1.35.1"

--- a/src/balance.rs
+++ b/src/balance.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
-use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::pubkey::Pubkey;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::signature::Signer;
 
 use crate::Miner;
 
@@ -19,13 +18,12 @@ impl Miner {
         } else {
             signer.pubkey()
         };
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
         let token_account_address = spl_associated_token_account::get_associated_token_address(
             &address,
             &ore::MINT_ADDRESS,
         );
-        match client.get_token_account(&token_account_address).await {
+
+        match &self.rpc_client.get_token_account(&token_account_address).await {
             Ok(token_account) => {
                 if let Some(token_account) = token_account {
                     println!("{:} ORE", token_account.token_amount.ui_amount_string);

--- a/src/busses.rs
+++ b/src/busses.rs
@@ -1,15 +1,11 @@
 use ore::{state::Bus, utils::AccountDeserialize, BUS_ADDRESSES};
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
 
 use crate::Miner;
 
 impl Miner {
     pub async fn busses(&self) {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
         for address in BUS_ADDRESSES.iter() {
-            let data = client.get_account_data(address).await.unwrap();
+            let data = &self.rpc_client.get_account_data(address).await.unwrap();
             match Bus::try_from_bytes(&data) {
                 Ok(bus) => {
                     println!("Bus {}: {:} ORE", bus.id, bus.rewards);

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -4,7 +4,7 @@ use ore::{self, state::Proof, utils::AccountDeserialize};
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
-use crate::{utils::proof_pubkey, Miner};
+use crate::{send_and_confirm::{CU_LIMIT_ATA, CU_LIMIT_CLAIM}, utils::proof_pubkey, Miner};
 
 impl Miner {
     pub async fn claim(&self, beneficiary: Option<String>, amount: Option<f64>) {
@@ -32,7 +32,7 @@ impl Miner {
         };
         let amountf = (amount as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
         let ix = ore::instruction::claim(pubkey, beneficiary, amount);
-        match self.send_and_confirm(&[ix]).await {
+        match self.send_and_confirm(&[ix], CU_LIMIT_CLAIM).await {
             Ok(sig) => {
                 println!("Claimed {:} ORE to account {:}", amountf, beneficiary);
                 println!("{:?}", sig);
@@ -65,7 +65,7 @@ impl Miner {
             &ore::MINT_ADDRESS,
             &spl_token::id(),
         );
-        match self.send_and_confirm(&[ix]).await {
+        match self.send_and_confirm(&[ix], CU_LIMIT_ATA).await {
             Ok(_sig) => println!("Created token account {:?}", token_account_pubkey),
             Err(e) => println!("Transaction failed: {:?}", e),
         }

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -1,19 +1,23 @@
 use ore::TREASURY_ADDRESS;
 use solana_sdk::signature::Signer;
 
-use crate::Miner;
+use crate::{send_and_confirm::CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY, Miner};
 
 impl Miner {
     pub async fn initialize(&self) {
         // Return early if program is initialized
         let signer = self.signer();
-        if (&self.rpc_client).get_account(&TREASURY_ADDRESS).await.is_ok() {
+        if (&self.rpc_client)
+            .get_account(&TREASURY_ADDRESS)
+            .await
+            .is_ok()
+        {
             return;
         }
 
         // Sign and send transaction.
         let ix = ore::instruction::initialize(signer.pubkey());
-        self.send_and_confirm(&[ix])
+        self.send_and_confirm(&[ix], CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY)
             .await
             .expect("Transaction failed");
     }

--- a/src/initialize.rs
+++ b/src/initialize.rs
@@ -1,6 +1,5 @@
 use ore::TREASURY_ADDRESS;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::signature::Signer;
 
 use crate::Miner;
 
@@ -8,9 +7,7 @@ impl Miner {
     pub async fn initialize(&self) {
         // Return early if program is initialized
         let signer = self.signer();
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
-        if client.get_account(&TREASURY_ADDRESS).await.is_ok() {
+        if (&self.rpc_client).get_account(&TREASURY_ADDRESS).await.is_ok() {
             return;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ async fn main() {
     let websocket_url = compute_websocket_url(&args.rpc);
 
     let connection_cache = if args.use_quic {
-        ConnectionCache::new_quic("connection_cache_cli_program_v4_quic", 1)
+        ConnectionCache::new_quic("connection_cache_ore_clie_quic", 1)
     } else {
         ConnectionCache::with_udp("connection_cache_ore_cli_udp", 1)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ use solana_sdk::{
 struct Miner {
     pub keypair_filepath: Option<String>,
     pub priority_fee: u64,
-    pub(crate) rpc_client: Arc<RpcClient>,
     pub(crate) connection_cache: ConnectionCache,
+    pub(crate) rpc_client: Arc<RpcClient>,
     pub(crate) websocket_url: String,
 }
 
@@ -56,7 +56,7 @@ struct Args {
         long,
         value_name = "MICROLAMPORTS",
         help = "Number of microlamports to pay as priority fee per transaction",
-        default_value = "0"
+        default_value = "100000"
     )]
     priority_fee: u64,
 
@@ -181,14 +181,14 @@ async fn main() {
     let websocket_url = compute_websocket_url(&args.rpc);
 
     let connection_cache = if args.use_quic {
-        ConnectionCache::new_quic("connection_cache_ore_clie_quic", 1)
+        ConnectionCache::new_quic("connection_cache_ore_cli_quic", 1)
     } else {
         ConnectionCache::with_udp("connection_cache_ore_cli_udp", 1)
     };
 
     let rpc_client = Arc::new(RpcClient::new_with_commitment(
         args.rpc,
-        CommitmentConfig::confirmed(),
+        CommitmentConfig::processed(),
     ));
 
     // Initialize miner.

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ struct MineArgs {
         short,
         value_name = "THREAD_COUNT",
         help = "The number of threads to dedicate to mining",
-        default_value = "1"
+        default_value = "8"
     )]
     threads: u64,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ use solana_sdk::{
 };
 
 struct Miner {
-    pub keypair_filepath: Option<String>,
-    pub priority_fee: u64,
+    pub(crate) keypair_filepath: Option<String>,
+    pub(crate) priority_fee: u64,
     pub(crate) connection_cache: ConnectionCache,
     pub(crate) rpc_client: Arc<RpcClient>,
     pub(crate) websocket_url: String,

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -44,8 +44,8 @@ impl Miner {
         // Start mining loop
         loop {
             // Find a valid hash.
-            let treasury = get_treasury(self.cluster.clone()).await;
-            let proof = get_proof(self.cluster.clone(), signer.pubkey()).await;
+            let treasury = get_treasury(&self.rpc_client).await;
+            let proof = get_proof(&self.rpc_client, signer.pubkey()).await;
 
             // Escape sequence that clears the screen and the scrollback buffer
             stdout.write_all(b"\x1b[2J\x1b[3J\x1b[H").ok();
@@ -79,8 +79,8 @@ impl Miner {
                 }
 
                 // Reset if epoch has ended
-                let treasury = get_treasury(self.cluster.clone()).await;
-                let clock = get_clock_account(self.cluster.clone()).await;
+                let treasury = get_treasury(&self.rpc_client).await;
+                let clock = get_clock_account(&self.rpc_client).await;
                 let threshold = treasury.last_reset_at.saturating_add(EPOCH_DURATION);
                 if clock.unix_timestamp.ge(&threshold) || needs_reset {
                     let reset_ix = ore::instruction::reset(signer.pubkey());

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,5 +1,4 @@
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{commitment_config::CommitmentConfig, signature::Signer};
+use solana_sdk::signature::Signer;
 
 use crate::{utils::proof_pubkey, Miner};
 
@@ -8,9 +7,7 @@ impl Miner {
         // Return early if miner is already registered
         let signer = self.signer();
         let proof_address = proof_pubkey(signer.pubkey());
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
-        if client.get_account(&proof_address).await.is_ok() {
+        if (&self.rpc_client).get_account(&proof_address).await.is_ok() {
             return;
         }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,6 +1,6 @@
 use solana_sdk::signature::Signer;
 
-use crate::{utils::proof_pubkey, Miner};
+use crate::{send_and_confirm::CU_LIMIT_REGISTER, utils::proof_pubkey, Miner};
 
 impl Miner {
     pub async fn register(&self) {
@@ -14,7 +14,7 @@ impl Miner {
         // Sign and send transaction.
         println!("Generating challenge...");
         let ix = ore::instruction::register(signer.pubkey());
-        self.send_and_confirm(&[ix])
+        self.send_and_confirm(&[ix], CU_LIMIT_REGISTER)
             .await
             .expect("Transaction failed");
     }

--- a/src/rewards.rs
+++ b/src/rewards.rs
@@ -17,7 +17,7 @@ impl Miner {
         } else {
             self.signer().pubkey()
         };
-        let proof = get_proof(self.cluster.clone(), address).await;
+        let proof = get_proof(&self.rpc_client, address).await;
         let amount = (proof.claimable_rewards as f64) / 10f64.powf(ore::TOKEN_DECIMALS as f64);
         println!("{:} ORE", amount);
     }

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -2,130 +2,205 @@ use solana_client::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
     connection_cache::ConnectionCache,
     nonblocking::tpu_client::TpuClient,
-    rpc_config::RpcSimulateTransactionConfig,
+    rpc_config::RpcSendTransactionConfig,
+    send_and_confirm_transactions_in_parallel::{
+        send_and_confirm_transactions_in_parallel, SendAndConfirmConfig,
+    },
     tpu_client::TpuClientConfig,
 };
-use solana_program::instruction::{Instruction, InstructionError};
+use solana_program::instruction::Instruction;
+use solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool};
 use solana_sdk::{
-    commitment_config::CommitmentConfig,
+    commitment_config::{CommitmentConfig, CommitmentLevel},
     compute_budget::ComputeBudgetInstruction,
     signature::{Signature, Signer},
-    transaction::{Transaction, TransactionError},
+    transaction::Transaction,
 };
-use solana_transaction_status::UiTransactionEncoding;
 
 use crate::Miner;
 
+pub(crate) const CU_LIMIT_REGISTER: u32 = 7660;
+pub(crate) const CU_LIMIT_CLAIM: u32 = 11_000;
+pub(crate) const CU_LIMIT_ATA: u32 = 24_000;
+pub(crate) const CU_LIMIT_RESET: u32 = 12_200;
+pub(crate) const CU_LIMIT_MINE: u32 = 3200;
+
+// #[deprecated]
+pub(crate) const CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY: u32 = 30_000;
+
+type QuicTpuClient = TpuClient<QuicPool, QuicConnectionManager, QuicConfig>;
+
 impl Miner {
-    pub async fn send_and_confirm(&self, ixs: &[Instruction]) -> ClientResult<Signature> {
+    pub async fn send_and_confirm(
+        &self,
+        ixs: &[Instruction],
+        cu_limit: u32,
+    ) -> ClientResult<Signature> {
+        // self.send_and_confirm_with_rpc_client(ixs, cu_limit).await
+        self.send_and_confirm_in_parallel(ixs, cu_limit).await
+        // self.send_and_confirm_with_tpu_client(ixs, cu_limit).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn send_and_confirm_in_parallel(
+        &self,
+        ixs: &[Instruction],
+        cu_limit: u32,
+    ) -> ClientResult<Signature> {
         let signer = self.signer();
 
-        // Build tx
-        let (hash, slot) = (&self.rpc_client)
-            .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
-            .await
-            .unwrap();
+        let cu_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(cu_limit);
+        let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
+        let mut final_ixs = vec![];
+        final_ixs.extend_from_slice(&[cu_budget_ix, cu_price_ix]);
+        final_ixs.extend_from_slice(ixs);
+        let tx = Transaction::new_with_payer(&final_ixs, Some(&signer.pubkey()));
 
-        let mut tx = Transaction::new_with_payer(ixs, Some(&signer.pubkey()));
-        tx.sign(&[&signer], hash);
-
-        // Sim and prepend cu ixs
-        let sim_res = (&self.rpc_client)
-            .simulate_transaction_with_config(
-                &tx,
-                RpcSimulateTransactionConfig {
-                    sig_verify: false,
-                    replace_recent_blockhash: false,
-                    commitment: Some(CommitmentConfig::confirmed()),
-                    encoding: Some(UiTransactionEncoding::Base64),
-                    accounts: None,
-                    min_context_slot: Some(slot),
-                    inner_instructions: false,
-                },
-            )
-            .await;
-        if let Ok(sim_res) = sim_res {
-            match sim_res.value.err {
-                Some(err) => match err {
-                    TransactionError::InstructionError(_, InstructionError::Custom(e)) => {
-                        if e == 1 {
-                            log::info!("Needs reset!");
-                            return Err(ClientError {
-                                request: None,
-                                kind: ClientErrorKind::Custom("Needs reset".into()),
-                            });
-                        } else if e == 3 {
-                            log::info!("Hash invalid!");
-                            return Err(ClientError {
-                                request: None,
-                                kind: ClientErrorKind::Custom("Hash invalid".into()),
-                            });
-                        } else if e == 5 {
-                            return Err(ClientError {
-                                request: None,
-                                kind: ClientErrorKind::Custom("Bus insufficient".into()),
-                            });
-                        } else {
-                            return Err(ClientError {
-                                request: None,
-                                kind: ClientErrorKind::Custom("Sim failed".into()),
-                            });
-                        }
-                    }
-                    _ => {
-                        return Err(ClientError {
-                            request: None,
-                            kind: ClientErrorKind::Custom("Sim failed".into()),
-                        })
-                    }
-                },
-                None => {
-                    let cu_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(
-                        sim_res.value.units_consumed.unwrap() as u32 + 1000,
-                    );
-                    let cu_price_ix =
-                        ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
-                    let mut final_ixs = vec![];
-                    final_ixs.extend_from_slice(&[cu_budget_ix, cu_price_ix]);
-                    final_ixs.extend_from_slice(ixs);
-                    tx = Transaction::new_with_payer(&final_ixs, Some(&signer.pubkey()));
-                    tx.sign(&[&signer], hash);
-                }
-            }
-        } else {
-            return Err(ClientError {
-                request: None,
-                kind: ClientErrorKind::Custom("Failed simulation".into()),
-            });
+        let tpu_client: Option<QuicTpuClient> = match &self.connection_cache {
+            ConnectionCache::Quic(cache) => {
+                let tpu_client = TpuClient::new_with_connection_cache(
+                    self.rpc_client.clone(),
+                    &self.websocket_url,
+                    TpuClientConfig::default(),
+                    cache.clone(),
+                )
+                .await
+                .expect("quic tpu client");
+                Some(tpu_client)
+            },
+            _ => None,
         };
 
-        match &self.connection_cache {
-            ConnectionCache::Quic(cache) => {
-                TpuClient::new_with_connection_cache(
-                    self.rpc_client.clone(),
-                    &self.websocket_url,
-                    TpuClientConfig::default(),
-                    cache.clone(),
-                )
-                .await
-                .expect("quic tpu client")
-                .send_and_confirm_messages_with_spinner(&[tx.message], &[&signer])
-                .await
+        let possible_tx_errors = send_and_confirm_transactions_in_parallel(
+            self.rpc_client.clone(),
+            tpu_client,
+            &[tx.message],
+            &[&signer],
+            SendAndConfirmConfig {
+                with_spinner: true,
+                resign_txs_count: Some(10),
+            },
+        )
+        .await
+        .map_err(|e| {
+            let kind = ClientErrorKind::Custom(e.to_string());
+            ClientError {
+                request: None,
+                kind,
             }
-            ConnectionCache::Udp(cache) => {
-                TpuClient::new_with_connection_cache(
-                    self.rpc_client.clone(),
-                    &self.websocket_url,
-                    TpuClientConfig::default(),
-                    cache.clone(),
-                )
-                .await
-                .expect("udp tpu client")
-                .send_and_confirm_messages_with_spinner(&[tx.message], &[&signer])
-                .await
+        })?;
+
+        eprintln!("possible_tx_errors: {:?}", possible_tx_errors);
+
+        Ok(tx.signatures[0])
+    }
+
+    #[allow(dead_code)]
+    pub async fn send_and_confirm_with_rpc_client(
+        &self,
+        ixs: &[Instruction],
+        cu_limit: u32,
+    ) -> ClientResult<Signature> {
+        #[allow(deprecated)]
+        let rpc_result = self
+            .rpc_client
+            .get_fees_with_commitment(CommitmentConfig::processed())
+            .await?;
+
+        let (blockhash, slot, _last_valid_block_height) = (
+            rpc_result.value.blockhash,
+            rpc_result.value.last_valid_block_height,
+            rpc_result.context.slot,
+        );
+
+        let signer = self.signer();
+
+        let cu_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(cu_limit);
+        let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
+
+        let mut final_ixs = vec![];
+        final_ixs.extend_from_slice(&[cu_budget_ix, cu_price_ix]);
+        final_ixs.extend_from_slice(ixs);
+
+        let mut tx = Transaction::new_with_payer(&final_ixs, Some(&signer.pubkey()));
+        tx.sign(&[&signer], blockhash);
+
+        let signature = self
+            .rpc_client
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &tx,
+                CommitmentConfig::confirmed(),
+                RpcSendTransactionConfig {
+                    max_retries: Some(0),
+                    min_context_slot: Some(slot),
+                    preflight_commitment: Some(CommitmentLevel::Processed),
+                    skip_preflight: true,
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        Ok(signature)
+    }
+
+    #[allow(dead_code)]
+    pub async fn send_and_confirm_with_tpu_client(
+        &self,
+        ixs: &[Instruction],
+        cu_limit: u32,
+    ) -> ClientResult<Signature> {
+        let signer = self.signer();
+
+        let cu_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(cu_limit);
+        let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
+
+        let mut final_ixs = vec![];
+        final_ixs.extend_from_slice(&[cu_budget_ix, cu_price_ix]);
+        final_ixs.extend_from_slice(ixs);
+        let tx = Transaction::new_with_payer(&final_ixs, Some(&signer.pubkey()));
+
+        for retry in (0..20).rev() {
+            let tx = tx.clone();
+
+            let outcome = match &self.connection_cache {
+                ConnectionCache::Quic(cache) => {
+                    let tpu_client = TpuClient::new_with_connection_cache(
+                        self.rpc_client.clone(),
+                        &self.websocket_url,
+                        TpuClientConfig::default(),
+                        cache.clone(),
+                    )
+                    .await
+                    .expect("quic tpu client");
+
+                    tpu_client
+                        .send_and_confirm_messages_with_spinner(&[tx.message], &[&signer])
+                        .await
+                }
+                ConnectionCache::Udp(cache) => {
+                    let tpu_client = TpuClient::new_with_connection_cache(
+                        self.rpc_client.clone(),
+                        &self.websocket_url,
+                        TpuClientConfig::default(),
+                        cache.clone(),
+                    )
+                    .await
+                    .expect("udp tpu client");
+
+                    tpu_client
+                        .send_and_confirm_messages_with_spinner(&[tx.message], &[&signer])
+                        .await
+                }
+            };
+
+            if outcome.is_ok() {
+                break;
+            } else {
+                eprintln!("outcome: {:?}", outcome);
+                eprintln!("retrying: {}", retry);
+                continue;
             }
         }
-        .expect("send and confirm to win");
 
         Ok(tx.signatures[0])
     }

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -6,7 +6,7 @@ use solana_client::{
     send_and_confirm_transactions_in_parallel::{
         send_and_confirm_transactions_in_parallel, SendAndConfirmConfig,
     },
-    tpu_client::TpuClientConfig,
+    tpu_client::{TpuClientConfig, MAX_FANOUT_SLOTS},
 };
 use solana_program::instruction::{Instruction, InstructionError};
 use solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool};
@@ -61,7 +61,9 @@ impl Miner {
                 let tpu_client = TpuClient::new_with_connection_cache(
                     self.rpc_client.clone(),
                     &self.websocket_url,
-                    TpuClientConfig::default(),
+                    TpuClientConfig {
+                        fanout_slots: MAX_FANOUT_SLOTS,
+                    },
                     cache.clone(),
                 )
                 .await

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use solana_client::{
     client_error::{ClientError, ClientErrorKind, Result as ClientResult},
     connection_cache::ConnectionCache,

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -80,7 +80,7 @@ impl Miner {
             &[&signer],
             SendAndConfirmConfig {
                 with_spinner: true,
-                resign_txs_count: Some(10),
+                resign_txs_count: Some(50),
             },
         )
         .await
@@ -96,13 +96,11 @@ impl Miner {
             match tx_error {
                 TransactionError::InstructionError(_, InstructionError::Custom(e)) => {
                     if e == 1 {
-                        log::info!("Needs reset!");
                         return Err(ClientError {
                             request: None,
                             kind: ClientErrorKind::Custom(format!("Needs reset e={}", e)),
                         });
                     } else if e == 3 {
-                        log::info!("Hash invalid!");
                         return Err(ClientError {
                             request: None,
                             kind: ClientErrorKind::Custom(format!("Hash invalid e={}", e)),
@@ -113,13 +111,16 @@ impl Miner {
                             kind: ClientErrorKind::Custom(format!("Bus insufficient e={}", e)),
                         });
                     } else {
-                        return Err(ClientError {
-                            request: None,
-                            kind: ClientErrorKind::Custom(format!("Sim failed e={}", e)),
-                        });
+                        eprintln!("Sim failed e={}", e);
+                        continue;
+                        // return Err(ClientError {
+                        //     request: None,
+                        //     kind: ClientErrorKind::Custom(format!("Sim failed e={}", e)),
+                        // });
                     }
                 }
                 _ => {
+                    eprintln!("unknown tx_error={}", tx_error);
                     return Err(ClientError {
                         request: None,
                         kind: ClientErrorKind::Custom(tx_error.to_string()),

--- a/src/treasury.rs
+++ b/src/treasury.rs
@@ -1,6 +1,3 @@
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
-
 use crate::{
     utils::{get_treasury, treasury_tokens_pubkey},
     Miner,
@@ -8,11 +5,9 @@ use crate::{
 
 impl Miner {
     pub async fn treasury(&self) {
-        let client =
-            RpcClient::new_with_commitment(self.cluster.clone(), CommitmentConfig::confirmed());
-        if let Ok(Some(treasury_tokens)) = client.get_token_account(&treasury_tokens_pubkey()).await
+        if let Ok(Some(treasury_tokens)) = (&self.rpc_client).get_token_account(&treasury_tokens_pubkey()).await
         {
-            let treasury = get_treasury(self.cluster.clone()).await;
+            let treasury = get_treasury(&self.rpc_client).await;
             let balance = treasury_tokens.token_amount.ui_amount_string;
             println!("{:} ORE", balance);
             println!("Admin: {}", treasury.admin);

--- a/src/update_admin.rs
+++ b/src/update_admin.rs
@@ -3,14 +3,14 @@ use std::str::FromStr;
 use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
-use crate::Miner;
+use crate::{send_and_confirm::CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY, Miner};
 
 impl Miner {
     pub async fn update_admin(&self, new_admin: String) {
         let signer = self.signer();
         let new_admin = Pubkey::from_str(new_admin.as_str()).unwrap();
         let ix = ore::instruction::update_admin(signer.pubkey(), new_admin);
-        self.send_and_confirm(&[ix])
+        self.send_and_confirm(&[ix], CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY)
             .await
             .expect("Transaction failed");
     }

--- a/src/update_difficulty.rs
+++ b/src/update_difficulty.rs
@@ -1,7 +1,7 @@
 use solana_program::keccak::Hash as KeccakHash;
 use solana_sdk::signature::Signer;
 
-use crate::Miner;
+use crate::{send_and_confirm::CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY, Miner};
 
 impl Miner {
     pub async fn update_difficulty(&self) {
@@ -17,7 +17,7 @@ impl Miner {
         let ix = ore::instruction::update_difficulty(signer.pubkey(), new_difficulty.into());
         // let bs58data = bs58::encode(ix.data).into_string();
         // println!("Data: {:?}", bs58data);
-        self.send_and_confirm(&[ix])
+        self.send_and_confirm(&[ix], CU_LIMIT_UNINFORMED_GUESSWORK_TO_MAKE_COMPILER_HAPPY)
             .await
             .expect("Transaction failed");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,11 +7,10 @@ use ore::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::{pubkey::Pubkey, sysvar};
-use solana_sdk::{clock::Clock, commitment_config::CommitmentConfig};
+use solana_sdk::clock::Clock;
 use spl_associated_token_account::get_associated_token_address;
 
-pub async fn get_treasury(cluster: String) -> Treasury {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_treasury(client: &RpcClient) -> Treasury {
     let data = client
         .get_account_data(&TREASURY_ADDRESS)
         .await
@@ -19,8 +18,7 @@ pub async fn get_treasury(cluster: String) -> Treasury {
     *Treasury::try_from_bytes(&data).expect("Failed to parse treasury account")
 }
 
-pub async fn get_proof(cluster: String, authority: Pubkey) -> Proof {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_proof(client: &RpcClient, authority: Pubkey) -> Proof {
     let proof_address = proof_pubkey(authority);
     let data = client
         .get_account_data(&proof_address)
@@ -29,8 +27,7 @@ pub async fn get_proof(cluster: String, authority: Pubkey) -> Proof {
     *Proof::try_from_bytes(&data).expect("Failed to parse miner account")
 }
 
-pub async fn get_clock_account(cluster: String) -> Clock {
-    let client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
+pub async fn get_clock_account(client: &RpcClient) -> Clock {
     let data = client
         .get_account_data(&sysvar::clock::ID)
         .await


### PR DESCRIPTION
Experiment that introduces tpu_client.send_and_confirm_messages_with_spinner.
Also uses one and only one rpc_client and a connection_cache.

The UX looks like this now:
```bash
Searching for valid hash...
1112i44tLJehFB15XVzJpEsdQAKvv5snM1Z7fL9JrnxA
Submitting hash for validation...

"Sim failed"

"Sim failed"
Blockhash expired. 4 retries remaining
Blockhash expired. 3 retries remaining
Blockhash expired. 2 retries remaining
Blockhash expired. 1 retries remaining
Blockhash expired. 0 retries remaining
thread 'main' panicked at src/send_and_confirm.rs:129:11:
send and confirm to win: Custom("Max retries exceeded")
stack backtrace:
[redacted]
```