### PR TITLE
add loop or not choice for mine

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,13 @@ struct MineArgs {
         default_value = "1"
     )]
     threads: u64,
+
+    #[arg(
+        long,
+        value_name = "USE_LOOP_MINER",
+        help = "Use loop miner (true) or not (false)",
+    )]
+    loopminer: Option<bool>,
 }
 
 #[derive(Parser, Debug)]
@@ -210,7 +217,7 @@ async fn main() {
             miner.treasury().await;
         }
         Commands::Mine(args) => {
-            miner.mine(args.threads).await;
+            miner.mine(args.threads, args.loopminer).await;
         }
         Commands::Claim(args) => {
             miner.claim(cluster, args.beneficiary, args.amount).await;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -23,7 +23,7 @@ use crate::{
 const RESET_ODDS: u64 = 20;
 
 impl Miner {
-    pub async fn mine(&self, threads: u64) {
+    pub async fn mine(&self, threads: u64, loopminer: Option<bool>) {
         // Register, if needed.
         let signer = self.signer();
         self.register().await;
@@ -98,6 +98,11 @@ impl Miner {
                         // TODO
                     }
                 }
+            }
+            
+            match loopminer {
+                Some(false) => break,
+                _ => {} // Do nothing for Some(true) or None
             }
         }
     }


### PR DESCRIPTION
Add an optional Boolean argument `--loopminer` to `mine` command. When set to `false`, the miner will exit after completing one mining process.