### PR TITLE
added fee estimation if RPC supports it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,8 @@ dependencies = [
  "log",
  "ore-program",
  "rand 0.8.5",
+ "serde",
+ "serde_json",
  "solana-cli-config",
  "solana-client",
  "solana-program",
@@ -3198,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,9 @@ solana-program = "^1.16"
 solana-sdk = "^1.16"
 solana-transaction-status = "^1.16"
 spl-token = { version = "^4", features = ["no-entrypoint"] }
-spl-associated-token-account = { version = "^2.2", features = [ "no-entrypoint" ] }
+spl-associated-token-account = { version = "^2.2", features = [
+  "no-entrypoint",
+] }
 tokio = "1.35.1"
+serde = "1.0.197"
+serde_json = "1.0.115"

--- a/src/estimate_fees.rs
+++ b/src/estimate_fees.rs
@@ -1,0 +1,95 @@
+use solana_client::rpc_request::RpcRequest;
+use solana_sdk::{
+    instruction::Instruction, message::Message, pubkey::Pubkey, transaction::Transaction,
+};
+
+use crate::Miner;
+
+impl Miner {
+    pub async fn get_priority_fee_estimate(&self, ixs: &[Instruction], payer: &Pubkey) -> u64 {
+        let client = self.rpc_client.clone();
+        let tx = Transaction::new_unsigned(Message::new(ixs, Some(payer)));
+        let param = serde_json::json!([GetPriorityFeeEstimateRequest {
+            transaction: Some(bs58::encode(bincode::serialize(&tx).unwrap()).into_string()),
+            options: Some(GetPriorityFeeEstimateOptions {
+                priority_level: Some(self.priority_level),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]);
+
+        let response: GetPriorityFeeEstimateResponse = client
+            .send(
+                RpcRequest::Custom {
+                    method: "getPriorityFeeEstimate",
+                },
+                param,
+            )
+            .await
+            .expect("Failed to get priority fee estimate");
+
+        response
+            .priority_fee_estimate
+            .expect("Failed to get priority fee estimate")
+            .round() as u64
+    }
+}
+
+#[derive(
+    serde::Deserialize,
+    serde::Serialize,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    clap::ValueEnum,
+)]
+pub enum PriorityLevel {
+    Min,      // 0th percentile
+    Low,      // 25th percentile
+    Medium,   // 50th percentile
+    High,     // 75th percentile
+    VeryHigh, // 95th percentile
+    // labelled unsafe to prevent people using and draining their funds by accident
+    UnsafeMax, // 100th percentile
+    Default,   // 50th percentile
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct GetPriorityFeeEstimateRequest {
+    transaction: Option<String>,       // estimate fee for a serialized txn
+    account_keys: Option<Vec<String>>, // estimate fee for a list of accounts
+    options: Option<GetPriorityFeeEstimateOptions>,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct GetPriorityFeeEstimateOptions {
+    priority_level: Option<PriorityLevel>, // Default to MEDIUM
+    include_all_priority_fee_levels: Option<bool>, // Include all priority level estimates in the response
+    transaction_encoding: Option<solana_transaction_status::UiTransactionEncoding>, // Default Base58
+    lookback_slots: Option<u8>, // number of slots to look back to calculate estimate. Valid number are 1-150, defualt is 150
+}
+
+#[derive(serde::Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GetPriorityFeeEstimateResponse {
+    priority_fee_estimate: Option<MicroLamportPriorityFee>,
+    // priority_fee_levels: Option<serde_json::Value>,
+}
+
+type MicroLamportPriorityFee = f64;
+// #[derive(serde::Deserialize, Debug)]
+// #[serde(rename_all = "camelCase")]
+// struct MicroLamportPriorityFeeLevels {
+//     none: f64,
+//     low: f64,
+//     medium: f64,
+//     high: f64,
+//     very_high: f64,
+//     unsafe_max: f64,
+// }


### PR DESCRIPTION
adds `--estimate-fees` and `--priority-level <min/low/medium/high/very-high/unsafe-max/default>`

takes the fee estimation stuff from #44 and removes the Helius requirement, though I think Helius is the only RPC that supports it