### PR TITLE
UI Work to improve clarity of mining process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+	"rust-analyzer.linkedProjects": [
+		"./Cargo.toml",
+		"./Cargo.toml",
+		"./Cargo.toml",
+		"./Cargo.toml"
+	]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "chrono",
  "clap 4.4.12",
  "futures",
+ "jobserver",
  "log",
  "ore-program",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cached = "0.46.1"
 chrono = "0.4.34"
 clap = { version = "4.4.12", features = ["derive"] }
 futures = "0.3.30"
+jobserver = "0.1.27"
 log = "0.4"
 ore = { version = "1.2.1", package = "ore-program" }
 rand = "0.8.4"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-echo ------------------------------------------------
-echo Building release version of ore-cli...
+echo ------------------------------------------------------------
+echo `date +'%Y-%m-%d %H:%M:%S'` Building release version of ore-cli...
 cargo build --release; 
-echo ------------------------------------------------
-echo "Built version: $(target/release/ore --version)"
+echo ------------------------------------------------------------
+echo "`date +'%Y-%m-%d %H:%M:%S'` Built version: $(target/release/ore --version)"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+echo ------------------------------------------------
+echo Building release version of ore-cli...
+cargo build --release; 
+echo ------------------------------------------------
+echo "Built version: $(target/release/ore --version)"

--- a/lookupPrices.sh
+++ b/lookupPrices.sh
@@ -1,0 +1,13 @@
+
+INITIAL_SOL_PRICE=$(curl -s "https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd" | jq '.solana.usd')
+if [ "${INITIAL_SOL_PRICE}" == "null" ]; then
+	echo "`date +'%Y-%m-%d %H:%M:%S'` Failed to download the current SOL price :("
+	INITIAL_SOL_PRICE="0.00"
+fi
+export SOL_PRICE
+INITIAL_ORE_PRICE=$(curl -s "https://api.coingecko.com/api/v3/simple/price?ids=ore&vs_currencies=usd" | jq '.ore.usd')
+if [ "${INITIAL_ORE_PRICE}" == "null" ]; then
+	echo "`date +'%Y-%m-%d %H:%M:%S'` Failed to download the current ORE price :("
+	INITIAL_ORE_PRICE="0.00"
+fi
+export ORE_PRICE

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -42,7 +42,7 @@ impl Miner {
         let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_CLAIM);
         let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
         let claim_ix = ore::instruction::claim(pubkey, beneficiary, amount);
-        print!("CLAIM Rewards:\tSubmitting claim transaction...priority_fee: {:?}", self.priority_fee);
+        print!("CLAIM Rewards:\tSubmitting claim transaction...priority_fee: {:?} ", self.priority_fee);
         match self
             .send_and_confirm(&[cu_limit_ix, cu_price_ix, claim_ix], false, false)
             .await

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -26,7 +26,7 @@ impl Miner {
                     proof.claimable_rewards
                 }
                 Err(err) => {
-                    println!("Error looking up claimable rewards: {:?}", err);
+                    println!("CLAIM Rewards:\t[ERROR] looking up claimable rewards: {:?}", err);
                     return;
                 }
             }
@@ -35,17 +35,17 @@ impl Miner {
         let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_CLAIM);
         let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
         let ix = ore::instruction::claim(pubkey, beneficiary, amount);
-        println!("Submitting claim transaction...");
+        println!("CLAIM Rewards:\tSubmitting claim transaction...priority_fee: {:?}", self.priority_fee);
         match self
             .send_and_confirm(&[cu_limit_ix, cu_price_ix, ix], false, false)
             .await
         {
             Ok(sig) => {
-                println!("Claimed {:} ORE to account {:}", amountf, beneficiary);
+                println!("CLAIM Rewards:\t[SUCCESS] Claimed {:} ORE to account {:}", amountf, beneficiary);
                 println!("{:?}", sig);
             }
             Err(err) => {
-                println!("Error: {:?}", err);
+                eprintln!("CLAIM Rewards:\t[Error]\t{:?}", err);
             }
         }
     }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -2,9 +2,16 @@ use std::str::FromStr;
 
 use ore::{self, state::Proof, utils::AccountDeserialize};
 use solana_program::pubkey::Pubkey;
-use solana_sdk::{compute_budget::ComputeBudgetInstruction, signature::Signer};
+use solana_sdk::{
+	compute_budget::ComputeBudgetInstruction, 
+	signature::Signer,
+};
 
-use crate::{cu_limits::CU_LIMIT_CLAIM, utils::proof_pubkey, Miner};
+use crate::{
+	cu_limits::CU_LIMIT_CLAIM, 
+	utils::proof_pubkey, 
+	Miner,
+};
 
 impl Miner {
     pub async fn claim(&self, beneficiary: Option<String>, amount: Option<f64>) {
@@ -34,10 +41,10 @@ impl Miner {
         let amountf = (amount as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
         let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_CLAIM);
         let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
-        let ix = ore::instruction::claim(pubkey, beneficiary, amount);
-        println!("CLAIM Rewards:\tSubmitting claim transaction...priority_fee: {:?}", self.priority_fee);
+        let claim_ix = ore::instruction::claim(pubkey, beneficiary, amount);
+        print!("CLAIM Rewards:\tSubmitting claim transaction...priority_fee: {:?}", self.priority_fee);
         match self
-            .send_and_confirm(&[cu_limit_ix, cu_price_ix, ix], false, false)
+            .send_and_confirm(&[cu_limit_ix, cu_price_ix, claim_ix], false, false)
             .await
         {
             Ok(sig) => {

--- a/src/cu_limits.rs
+++ b/src/cu_limits.rs
@@ -1,3 +1,3 @@
-pub const CU_LIMIT_CLAIM: u32 = 11_000;
-pub const CU_LIMIT_RESET: u32 = 12_200;
+pub const CU_LIMIT_CLAIM: u32 = 11000;
+pub const CU_LIMIT_RESET: u32 = 12200;
 pub const CU_LIMIT_MINE: u32 = 3200;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -53,9 +53,9 @@ impl Miner {
 				initial_sol_balance=sol_balance;
 			} else {			
             	println!("\n\n\n\n\n");								// Add a few empty lines between passes
+				println!("-------------------------------------------------------------------------------");
 			}
             // stdout.write_all(b"\x1b[2J\x1b[3J\x1b[H").ok();	// Clear the terminal windows - hides previous path from scroll buffer
-			println!("-------------------------------------------------------------------------------");
             println!("Mining Pass {}", mining_passes);
 			println!("-------------------------------------------------------------------------------");
             // stdout.write_all(b"\x1b[2J\x1b[3J\x1b[H").ok();
@@ -65,7 +65,7 @@ impl Miner {
             println!("Initial ORE Price:\t${:.2}", self.initial_ore_price);
             println!("SOL Balance:\t\t{:.9}\t${:.2}\tUsed: {:.9}\t${:.2}", 
 					sol_balance, sol_balance*self.initial_sol_price, 
-					(sol_balance-initial_sol_balance), (sol_balance-initial_sol_balance)*self.initial_sol_price);
+					(initial_sol_balance-sol_balance), (initial_sol_balance-sol_balance)*self.initial_sol_price);
 			println!("ORE Balance:\t\t{:.9}\t${:.2}", balance, balance*self.initial_ore_price);
 			println!("ORE Claimable:\t\t{:.9}\t${:.2}", rewards, rewards*self.initial_ore_price);
 			println!("Session Rewards:\t{:.9}\t${:.2}\t(succeeded {} times)", 

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -109,10 +109,8 @@ impl Miner {
                     // There are a lot of miners right now, so randomly select into submitting tx
                     if rng.gen_range(0..RESET_ODDS).eq(&0) {
                         println!("Submit Hash {}:\tSending epoch reset transaction...", attempts);
-                        let cu_limit_ix =
-                            ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_RESET);
-                        let cu_price_ix =
-                            ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
+                        let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_RESET);
+                        let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
                         let reset_ix = ore::instruction::reset(signer.pubkey());
                         self.send_and_confirm(&[cu_limit_ix, cu_price_ix, reset_ix], false, true)
                             .await
@@ -125,8 +123,7 @@ impl Miner {
                 let bus_rewards = (bus.rewards as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
 				print!("Submit Hash {}:\tSending on bus {} ({} ORE) priority_fee: {:?}\t", attempts, bus.id, bus_rewards, self.priority_fee);
                 let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_MINE);
-                let cu_price_ix =
-                    ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
+                let cu_price_ix = ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
                 let ix_mine = ore::instruction::mine(
                     signer.pubkey(),
                     BUS_ADDRESSES[bus.id as usize],

--- a/src/register.rs
+++ b/src/register.rs
@@ -13,10 +13,10 @@ impl Miner {
         }
 
         // Sign and send transaction.
-        println!("Generating challenge...");
+        print!("Generating challenge...");
         'send: loop {
             let ix = ore::instruction::register(signer.pubkey());
-            if self.send_and_confirm(&[ix], true, false).await.is_ok() {
+            if self.send_and_confirm(&[ix], false, false).await.is_ok() {
                 break 'send;
             }
         }

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -63,7 +63,7 @@ impl Miner {
         let mut tx = Transaction::new_with_payer(ixs, Some(&signer.pubkey()));
 
         // Simulate tx
-        let mut sim_attempts = 1;
+        let mut sim_attempts = 0;
 		'simulate: loop {
 			sim_attempts += 1;
             let sim_res = client
@@ -112,7 +112,6 @@ impl Miner {
             }
 
             // Abort if sim fails
-			sim_attempts += 1;
             if sim_attempts.gt(&SIMULATION_RETRIES) {
                 return Err(ClientError {
                     request: None,

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -129,7 +129,7 @@ impl Miner {
 
 		
         // Submit tx
-        tx.sign(&[&signer], hash).await;
+        tx.sign(&[&signer], hash);
 
         // let mut sigs = vec![];
         let mut attempts = 0;

--- a/startMiner.sh
+++ b/startMiner.sh
@@ -1,0 +1,41 @@
+#bin/bash
+#
+# This script will start up a basic ore-cli miner
+
+# Enter the URL for your desired RPC server
+DEFAULT_RPC_URL="https://quaint-proud-dew.solana-mainnet.quiknode.pro/XXXXXXXXXXXXXXXXXXXXXX/"
+# Enter the path to your local wallet config file
+DEFAULT_KEY=~/.config/solana/id.ore_web.json
+MINER_NAME="Miner 1"
+
+DEFAULT_FEE=100
+DEFAULT_THREADS=4
+
+RPC_URL=$DEFAULT_RPC_URL
+KEY=$DEFAULT_KEY
+FEE=$DEFAULT_FEE
+THREADS=$DEFAULT_THREADS
+
+ORE_BIN=ore
+# Redirect to use the compiled version of your client. Comment out if you are not compiling your own ore-cli
+ORE_BIN=~/ore-cli/target/release/ore
+
+
+while true; do
+	echo -------------------------------------------------------------------------------
+	echo `date +'%Y-%m-%d %H:%M:%S'` Starting ${MINER_NAME}.....
+	echo `date +'%Y-%m-%d %H:%M:%S'` RPC: ${RPC_URL}
+	echo `date +'%Y-%m-%d %H:%M:%S'` ore-cli: ${ORE_BIN}
+
+	source ./lookupPrices.sh
+	echo `date +'%Y-%m-%d %H:%M:%S'` "Initial SOL Price:	\$${SOL_PRICE}"
+	echo `date +'%Y-%m-%d %H:%M:%S'` "Initial ORE Price:	\$${ORE_PRICE}"
+	echo -------------------------------------------------------------------------------
+	# start the miner
+	COMMAND="${ORE_BIN} --rpc ${RPC_URL} --keypair ${KEY} --priority-fee ${FEE} --initial-sol-price ${SOL_PRICE} --initial-ore-price ${ORE_PRICE} mine --threads ${THREADS}"
+	# echo ${COMMAND}
+	eval $COMMAND
+	[ $? -eq 0 ] && break
+	echo `date +'%Y-%m-%d %H:%M:%S'` "Restart in 5 seconds..."
+	sleep 5
+done


### PR DESCRIPTION
This is my first effort into rust programming so go easy.
Spent a few days working on trying to clarify the logging & output for the miner process. The original version was particularly verbose and caused lots of scrolling (particularly when the network is congested).

Main changes in this pull request:
- tidied up the output sent to the console to try and make it clearer and not quite so scrolly
- added 2 new arguments to the cli - initial_sol_price and initial_ore_price. These default to 0 but enable a conversion to display the actual cost of your ore & sol usage for normal humans to understand. See the lookupPrices.sh script for a way to retrieve the prices from coingecko
- log how long it takes to perform one pass of the miner from generating hash to submission.
- Incorporated a few tweaks from some of the other pull requests.
- Tried to optimise the delays in send_and_confirm to prevent spamming the RPC server constantly. Spamming it constantly does not make it respond quicker and actually makes the problems worse as the RPC is overloaded & has to rate limit everyone.

I realise that this logging may be too late but hopefully they may be a pointer for the next version of the client.


