### PR TITLE
API call reduction for busses script

### DIFF
--- a/src/busses.rs
+++ b/src/busses.rs
@@ -1,26 +1,32 @@
 use ore::{state::Bus, utils::AccountDeserialize, BUS_ADDRESSES, TOKEN_DECIMALS};
-use solana_client::client_error::Result;
 
 use crate::Miner;
 
 impl Miner {
     pub async fn busses(&self) {
         let client = self.rpc_client.clone();
+        let mut max_bus: Option<Bus> = None;
+        let mut max_rewards = 0.0;
+
         for address in BUS_ADDRESSES.iter() {
             let data = client.get_account_data(address).await.unwrap();
             match Bus::try_from_bytes(&data) {
                 Ok(bus) => {
                     let rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
                     println!("Bus {}: {:} ORE", bus.id, rewards);
+                    if rewards > max_rewards {
+                        max_rewards = rewards;
+                        max_bus = Some(*bus);
+                    }
                 }
                 Err(_) => {}
             }
         }
-    }
 
-    pub async fn get_bus(&self, id: usize) -> Result<Bus> {
-        let client = self.rpc_client.clone();
-        let data = client.get_account_data(&BUS_ADDRESSES[id]).await?;
-        Ok(*Bus::try_from_bytes(&data).unwrap())
+        if let Some(bus) = max_bus {
+            let max_rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
+            println!("Bus with the most rewards: Bus {}: {:} ORE", bus.id, max_rewards);
+        }
     }
 }
+

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -1,266 +1,206 @@
-use std::{
-    io::{stdout, Write},
-    sync::{atomic::AtomicBool, Arc, Mutex},
-};
+use std::{sync::Arc, time::Instant};
 
-use ore::{self, state::Bus, BUS_ADDRESSES, BUS_COUNT, EPOCH_DURATION};
-use rand::Rng;
-use solana_program::{keccak::HASH_BYTES, program_memory::sol_memcmp, pubkey::Pubkey};
-use solana_sdk::{
-    compute_budget::ComputeBudgetInstruction,
-    keccak::{hashv, Hash as KeccakHash},
-    signature::Signer,
+use colored::*;
+use drillx::{
+    equix::{self},
+    Hash, Solution,
 };
+use ore::{self, state::Proof, state::Bus, utils::AccountDeserialize, BUS_ADDRESSES, TOKEN_DECIMALS, EPOCH_DURATION};
+use solana_rpc_client::spinner;
+use solana_sdk::signer::Signer;
 
 use crate::{
-    cu_limits::{CU_LIMIT_MINE, CU_LIMIT_RESET},
-    utils::{get_clock_account, get_proof, get_treasury},
+    args::MineArgs,
+    send_and_confirm::ComputeBudget,
+    utils::{amount_u64_to_string, get_clock, get_config, get_proof},
     Miner,
 };
 
-// Odds of being selected to submit a reset tx
-const RESET_ODDS: u64 = 20;
-
 impl Miner {
-    pub async fn mine(&self, threads: u64) {
+    pub async fn mine(&self, args: MineArgs) {
         // Register, if needed.
         let signer = self.signer();
         self.register().await;
-        let mut stdout = stdout();
-        let mut rng = rand::thread_rng();
+
+        // Check num threads
+        self.check_num_cores(args.threads);
 
         // Start mining loop
         loop {
-            // Fetch account state
-            let balance = self.get_ore_display_balance().await;
-            let treasury = get_treasury(&self.rpc_client).await;
+            // Fetch proof
             let proof = get_proof(&self.rpc_client, signer.pubkey()).await;
-            let rewards =
-                (proof.claimable_rewards as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
-            let reward_rate =
-                (treasury.reward_rate as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
-            stdout.write_all(b"\x1b[2J\x1b[3J\x1b[H").ok();
-            println!("Balance: {} ORE", balance);
-            println!("Claimable: {} ORE", rewards);
-            println!("Reward rate: {} ORE", reward_rate);
+            println!(
+                "\nStake balance: {} ORE",
+                amount_u64_to_string(proof.balance)
+            );
 
-            // Escape sequence that clears the screen and the scrollback buffer
-            println!("\nMining for a valid hash...");
-            let (next_hash, nonce) =
-                self.find_next_hash_par(proof.hash.into(), treasury.difficulty.into(), threads);
+            // Calc cutoff time
+            let cutoff_time = self.get_cutoff(proof, args.buffer_time).await;
 
-            // Submit mine tx.
-            // Use busses randomly so on each epoch, transactions don't pile on the same busses
-            println!("\n\nSubmitting hash for validation...");
-            'submit: loop {
-                // Double check we're submitting for the right challenge
-                let proof_ = get_proof(&self.rpc_client, signer.pubkey()).await;
-                if !self.validate_hash(
-                    next_hash,
-                    proof_.hash.into(),
+            // Run drillx
+            let solution = Self::find_hash_par(proof, cutoff_time, args.threads).await;
+
+            // Submit most difficult hash
+            let mut ixs = vec![];
+            if self.needs_reset().await {
+                ixs.push(ore::instruction::reset(signer.pubkey()));
+            }
+            if let Some(bus_index) = self.find_bus().await {
+                let bus_address = BUS_ADDRESSES[bus_index];
+                ixs.push(ore::instruction::mine(
                     signer.pubkey(),
-                    nonce,
-                    treasury.difficulty.into(),
-                ) {
-                    println!("Hash already validated! An earlier transaction must have landed.");
-                    break 'submit;
-                }
-
-                // Reset epoch, if needed
-                let treasury = get_treasury(&self.rpc_client).await;
-                let clock = get_clock_account(&self.rpc_client).await;
-                let threshold = treasury.last_reset_at.saturating_add(EPOCH_DURATION);
-                if clock.unix_timestamp.ge(&threshold) {
-                    // There are a lot of miners right now, so randomly select into submitting tx
-                    if rng.gen_range(0..RESET_ODDS).eq(&0) {
-                        println!("Sending epoch reset transaction...");
-                        let cu_limit_ix =
-                            ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_RESET);
-                        let cu_price_ix =
-                            ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
-                        let reset_ix = ore::instruction::reset(signer.pubkey());
-                        self.send_and_confirm(&[cu_limit_ix, cu_price_ix, reset_ix], false, true)
-                            .await
-                            .ok();
-                    }
-                }
-
-                // Submit request.
-                let bus = self.find_bus_id(treasury.reward_rate).await;
-                let bus_rewards = (bus.rewards as f64) / (10f64.powf(ore::TOKEN_DECIMALS as f64));
-                println!("Sending on bus {} ({} ORE)", bus.id, bus_rewards);
-                let cu_limit_ix = ComputeBudgetInstruction::set_compute_unit_limit(CU_LIMIT_MINE);
-                let cu_price_ix =
-                    ComputeBudgetInstruction::set_compute_unit_price(self.priority_fee);
-                let ix_mine = ore::instruction::mine(
-                    signer.pubkey(),
-                    BUS_ADDRESSES[bus.id as usize],
-                    next_hash.into(),
-                    nonce,
-                );
-                match self
-                    .send_and_confirm(&[cu_limit_ix, cu_price_ix, ix_mine], false, false)
-                    .await
-                {
-                    Ok(sig) => {
-                        println!("Success: {}", sig);
-                        break;
-                    }
-                    Err(_err) => {
-                        // TODO
-                    }
-                }
+                    bus_address,
+                    solution,
+                ));
             }
+            self.send_and_confirm(&ixs, ComputeBudget::Fixed(500_000), false)
+                .await
+                .ok();
         }
     }
 
-    async fn find_bus_id(&self, reward_rate: u64) -> Bus {
-        let mut rng = rand::thread_rng();
-        loop {
-            let bus_id = rng.gen_range(0..BUS_COUNT);
-            if let Ok(bus) = self.get_bus(bus_id).await {
-                if bus.rewards.gt(&reward_rate.saturating_mul(20)) {
-                    return bus;
-                }
-            }
-        }
-    }
-
-    fn _find_next_hash(&self, hash: KeccakHash, difficulty: KeccakHash) -> (KeccakHash, u64) {
-        let signer = self.signer();
-        let mut next_hash: KeccakHash;
-        let mut nonce = 0u64;
-        loop {
-            next_hash = hashv(&[
-                hash.to_bytes().as_slice(),
-                signer.pubkey().to_bytes().as_slice(),
-                nonce.to_le_bytes().as_slice(),
-            ]);
-            if next_hash.le(&difficulty) {
-                break;
-            } else {
-                println!("Invalid hash: {} Nonce: {:?}", next_hash.to_string(), nonce);
-            }
-            nonce += 1;
-        }
-        (next_hash, nonce)
-    }
-
-    fn find_next_hash_par(
-        &self,
-        hash: KeccakHash,
-        difficulty: KeccakHash,
-        threads: u64,
-    ) -> (KeccakHash, u64) {
-        #[cfg(feature = "metrics")]
-        let span = tracing::info_span!(target: "otel", "finding next hash threads:{threads}");
-        #[cfg(feature = "metrics")]
-        let _guard = span.enter();
-
-        let found_solution = Arc::new(AtomicBool::new(false));
-        let solution = Arc::new(Mutex::<(KeccakHash, u64)>::new((
-            KeccakHash::new_from_array([0; 32]),
-            0,
-        )));
-        let signer = self.signer();
-        let pubkey = signer.pubkey();
-        let thread_handles: Vec<_> = (0..threads)
+    async fn find_hash_par(proof: Proof, cutoff_time: u64, threads: u64) -> Solution {
+        // Dispatch job to each thread
+        let progress_bar = Arc::new(spinner::new_progress_bar());
+        progress_bar.set_message("Mining...");
+        let handles: Vec<_> = (0..threads)
             .map(|i| {
                 std::thread::spawn({
-                    let found_solution = found_solution.clone();
-                    let solution = solution.clone();
-                    let mut stdout = stdout();
+                    let proof = proof.clone();
+                    let progress_bar = progress_bar.clone();
+                    let mut memory = equix::SolverMemory::new();
                     move || {
-                        let n = u64::MAX.saturating_div(threads).saturating_mul(i);
-                        let mut next_hash: KeccakHash;
-                        let mut nonce: u64 = n;
+                        let timer = Instant::now();
+                        let mut nonce = u64::MAX.saturating_div(threads).saturating_mul(i);
+                        let mut best_nonce = nonce;
+                        let mut best_difficulty = 0;
+                        let mut best_hash = Hash::default();
                         loop {
-                            next_hash = hashv(&[
-                                hash.to_bytes().as_slice(),
-                                pubkey.to_bytes().as_slice(),
-                                nonce.to_le_bytes().as_slice(),
-                            ]);
-                            if nonce % 10_000 == 0 {
-                                #[cfg(feature = "metrics")]
-                                tracing::info!(target: "otel",worker = i, monotonic_counter.miner = 1_u64);
+                            // Create hash
+                            if let Ok(hx) = drillx::hash_with_memory(
+                                &mut memory,
+                                &proof.challenge,
+                                &nonce.to_le_bytes(),
+                            ) {
+                                let difficulty = hx.difficulty();
+                                if difficulty.gt(&best_difficulty) {
+                                    best_nonce = nonce;
+                                    best_difficulty = difficulty;
+                                    best_hash = hx;
+                                }
+                            }
 
-                                if found_solution.load(std::sync::atomic::Ordering::Relaxed) {
-                                    return;
-                                }
-                                if n == 0 {
-                                    stdout
-                                        .write_all(
-                                            format!("\r{}", next_hash.to_string()).as_bytes(),
-                                        )
-                                        .ok();
+                            // Exit if time has elapsed
+                            if nonce % 100 == 0 {
+                                if timer.elapsed().as_secs().ge(&cutoff_time) {
+                                    if best_difficulty.gt(&ore::MIN_DIFFICULTY) {
+                                        // Mine until min difficulty has been met
+                                        break;
+                                    }
+                                } else if i == 0 {
+                                    progress_bar.set_message(format!(
+                                        "Mining... ({} sec remaining)",
+                                        cutoff_time.saturating_sub(timer.elapsed().as_secs()),
+                                    ));
                                 }
                             }
-                            if next_hash.le(&difficulty) {
-                                stdout
-                                    .write_all(format!("\r{}", next_hash.to_string()).as_bytes())
-                                    .ok();
-                                found_solution.store(true, std::sync::atomic::Ordering::Relaxed);
-                                let mut w_solution = solution.lock().expect("failed to lock mutex");
-                                *w_solution = (next_hash, nonce);
-                                return;
-                            }
+
+                            // Increment nonce
                             nonce += 1;
                         }
+
+                        // Return the best nonce
+                        (best_nonce, best_difficulty, best_hash)
                     }
                 })
             })
             .collect();
 
-        for thread_handle in thread_handles {
-            thread_handle.join().unwrap();
-        }
-
-        let r_solution = solution.lock().expect("Failed to get lock");
-        *r_solution
-    }
-
-    pub fn validate_hash(
-        &self,
-        hash: KeccakHash,
-        current_hash: KeccakHash,
-        signer: Pubkey,
-        nonce: u64,
-        difficulty: KeccakHash,
-    ) -> bool {
-        // Validate hash correctness
-        let hash_ = hashv(&[
-            current_hash.as_ref(),
-            signer.as_ref(),
-            nonce.to_le_bytes().as_slice(),
-        ]);
-        if sol_memcmp(hash.as_ref(), hash_.as_ref(), HASH_BYTES) != 0 {
-            return false;
-        }
-
-        // Validate hash difficulty
-        if hash.gt(&difficulty) {
-            return false;
-        }
-
-        true
-    }
-
-    pub async fn get_ore_display_balance(&self) -> String {
-        let client = self.rpc_client.clone();
-        let signer = self.signer();
-        let token_account_address = spl_associated_token_account::get_associated_token_address(
-            &signer.pubkey(),
-            &ore::MINT_ADDRESS,
-        );
-        match client.get_token_account(&token_account_address).await {
-            Ok(token_account) => {
-                if let Some(token_account) = token_account {
-                    token_account.token_amount.ui_amount_string
-                } else {
-                    "0.00".to_string()
+        // Join handles and return best nonce
+        let mut best_nonce = 0;
+        let mut best_difficulty = 0;
+        let mut best_hash = Hash::default();
+        for h in handles {
+            if let Ok((nonce, difficulty, hash)) = h.join() {
+                if difficulty > best_difficulty {
+                    best_difficulty = difficulty;
+                    best_nonce = nonce;
+                    best_hash = hash;
                 }
             }
-            Err(_) => "0.00".to_string(),
+        }
+
+        // Update log
+        progress_bar.finish_with_message(format!(
+            "Best hash: {} (difficulty: {})",
+            bs58::encode(best_hash.h).into_string(),
+            best_difficulty
+        ));
+
+        Solution::new(best_hash.d, best_nonce.to_le_bytes())
+    }
+
+    pub fn check_num_cores(&self, threads: u64) {
+        // Check num threads
+        let num_cores = num_cpus::get() as u64;
+        if threads.gt(&num_cores) {
+            println!(
+                "{} Number of threads ({}) exceeds available cores ({})",
+                "WARNING".bold().yellow(),
+                threads,
+                num_cores
+            );
         }
     }
+
+    async fn needs_reset(&self) -> bool {
+        let clock = get_clock(&self.rpc_client).await;
+        let config = get_config(&self.rpc_client).await;
+        config
+            .last_reset_at
+            .saturating_add(EPOCH_DURATION)
+            .saturating_sub(5) // Buffer
+            .le(&clock.unix_timestamp)
+    }
+
+    async fn get_cutoff(&self, proof: Proof, buffer_time: u64) -> u64 {
+        let clock = get_clock(&self.rpc_client).await;
+        proof
+            .last_hash_at
+            .saturating_add(60)
+            .saturating_sub(buffer_time as i64)
+            .saturating_sub(clock.unix_timestamp)
+            .max(0) as u64
+    }
+
+    pub async fn find_bus(&self) -> Option<usize> {
+        let client = self.rpc_client.clone();
+        let mut max_bus_index: Option<usize> = None;
+        let mut max_rewards = 0.0;
+        let mut max_bus: Option<Bus> = None; // Track the bus with max rewards
+    
+        for (index, address) in BUS_ADDRESSES.iter().enumerate() {
+            let data = client.get_account_data(address).await.unwrap();
+            match Bus::try_from_bytes(&data) {
+                Ok(bus) => {
+                    let rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
+                    if rewards > max_rewards {
+                        max_rewards = rewards;
+                        max_bus_index = Some(index);
+                        max_bus = Some(*bus); // Update the bus with max rewards
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+    
+        // Print the bus with the most rewards if found
+        if let Some(bus) = max_bus {
+            let max_rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
+            println!("Bus with the most rewards: Bus {}: {} ORE", bus.id, max_rewards);
+        }
+    
+        max_bus_index
+    }
+    
 }


### PR DESCRIPTION
Uses get_multiple_accounts instead of get_account_data to get all the accounts' data at once instead of needing an API call for each address.