### PR TITLE
Update busses.rs

### DIFF
--- a/src/busses.rs
+++ b/src/busses.rs
@@ -1,26 +1,26 @@
 use ore::{state::Bus, utils::AccountDeserialize, BUS_ADDRESSES, TOKEN_DECIMALS};
-use solana_client::client_error::Result;
 
 use crate::Miner;
 
 impl Miner {
     pub async fn busses(&self) {
         let client = self.rpc_client.clone();
-        for address in BUS_ADDRESSES.iter() {
-            let data = client.get_account_data(address).await.unwrap();
-            match Bus::try_from_bytes(&data) {
-                Ok(bus) => {
-                    let rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
-                    println!("Bus {}: {:} ORE", bus.id, rewards);
+        let data = client.get_multiple_accounts(&BUS_ADDRESSES).await.unwrap();
+
+        for (_address, account) in BUS_ADDRESSES.iter().zip(data.iter()) {
+            match account {
+                Some(account) => {
+                    let data_bytes = &account.data[..]; // Extract data bytes
+                    match Bus::try_from_bytes(data_bytes) {
+                        Ok(bus) => {
+                            let rewards = (bus.rewards as f64) / 10f64.powf(TOKEN_DECIMALS as f64);
+                            println!("Bus {}: {} ORE", bus.id, rewards);
+                        }
+                        Err(_) => {}
+                    }
                 }
-                Err(_) => {}
+                None => {}
             }
         }
-    }
-
-    pub async fn get_bus(&self, id: usize) -> Result<Bus> {
-        let client = self.rpc_client.clone();
-        let data = client.get_account_data(&BUS_ADDRESSES[id]).await?;
-        Ok(*Bus::try_from_bytes(&data).unwrap())
     }
 }


### PR DESCRIPTION
Uses get_multiple_accounts instead of get_account_data to get all the accounts' data at once instead of needing an API call for each address.