### PR TITLE
feat: add dynamic fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +482,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -1572,6 +1584,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,7 +1771,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -1885,13 +1931,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1923,9 +2003,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1938,17 +2018,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.30",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2318,6 +2454,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,10 +2696,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ore-api"
@@ -2585,6 +2776,8 @@ dependencies = [
  "ore-api",
  "ore-utils",
  "rand 0.8.5",
+ "reqwest 0.12.4",
+ "serde_json",
  "solana-cli-config",
  "solana-client",
  "solana-program",
@@ -2683,6 +2876,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
  "num",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.70",
 ]
 
 [[package]]
@@ -3061,10 +3274,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -3074,7 +3287,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3089,7 +3302,49 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3205,7 +3460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "schannel",
  "security-framework",
 ]
@@ -3218,6 +3473,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -3722,7 +3993,7 @@ dependencies = [
  "gethostname",
  "lazy_static",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "solana-sdk",
  "thiserror",
 ]
@@ -3870,7 +4141,7 @@ dependencies = [
  "crossbeam-channel",
  "futures-util",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -3954,7 +4225,7 @@ dependencies = [
  "bs58 0.4.0",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -3977,7 +4248,7 @@ dependencies = [
  "base64 0.21.7",
  "bs58 0.4.0",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.11.27",
  "semver",
  "serde",
  "serde_derive",
@@ -4781,6 +5052,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4867,6 +5148,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,7 +5221,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5039,6 +5341,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -5374,6 +5682,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ num_cpus = "1.16.0"
 ore-api = "2.1.0"
 ore-utils = "2.1.0"
 rand = "0.8.4"
+reqwest = { version = "0.12", features = ["json"] }
 solana-cli-config = "^1.18"
 solana-client = "^1.18"
 solana-program = "^1.18"
 solana-rpc-client = "^1.18"
 solana-sdk = "^1.18"
 solana-transaction-status = "^1.18"
+serde_json = "1.0"
 spl-token = { version = "^4", features = ["no-entrypoint"] }
 spl-associated-token-account = { version = "^2.3", features = [
   "no-entrypoint",

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -1,0 +1,33 @@
+use reqwest;
+use serde_json::{json, Value};
+
+pub async fn get_priority_fee_estimate(dynamic_fee_rpc_url: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let helius_url = dynamic_fee_rpc_url;
+
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": "helius-test",
+        "method": "getPriorityFeeEstimate",
+        "params": [{
+            "accountKeys": ["oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ"],
+            "options": {
+                "recommended": true
+            }
+        }]
+    });
+
+
+    let response: Value = client.post(helius_url)
+        .json(&body)
+        .send()
+        .await?
+        .json()
+        .await?;
+
+    let priority_fee = response["result"]["priorityFeeEstimate"]
+        .as_f64()
+        .ok_or_else(|| format!("Failed to parse priority fee. Response: {:?}", response))?;
+
+    Ok(priority_fee as u64)
+}

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -56,7 +56,7 @@ impl Miner {
                     .await
                     .unwrap();
 
-                match strategy.as_str() {
+                let calculated_fee = match strategy.as_str() {
                     "helius" => response["result"]["priorityFeeEstimate"]
                         .as_f64()
                         .map(|fee| fee as u64)
@@ -73,6 +73,13 @@ impl Miner {
                         })
                         .unwrap(),
                     _ => return self.priority_fee.unwrap_or(0),
+                };
+
+                // Check if the calculated fee is higher than self.dynamic_fee_max
+                if let Some(max_fee) = self.dynamic_fee_max {
+                    calculated_fee.min(max_fee)
+                } else {
+                    calculated_fee
                 }
             }
         }

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -11,8 +11,8 @@ pub async fn get_priority_fee_estimate(
 
     if dynamic_fee_strategy == "helius" {
       result_spec = "helius"
-    } else if dynamic_fee_strategy == "rpcpool" {
-      result_spec = "rpcpool"
+    } else if dynamic_fee_strategy == "triton" {
+      result_spec = "triton"
     } else {
       result_spec = "helius"
     }
@@ -20,7 +20,7 @@ pub async fn get_priority_fee_estimate(
 
     let body;
 
-    if result_spec == "rpcpool" {
+    if result_spec == "triton" {
         // Use the improved priority fees API
         body = json!({
             "jsonrpc": "2.0",
@@ -55,7 +55,7 @@ pub async fn get_priority_fee_estimate(
         .json()
         .await?;
 
-    let priority_fee = if result_spec == "rpcpool" {
+    let priority_fee = if result_spec == "triton" {
         // Parse the improved priority fees API response
         response["result"]
             .as_array()

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -1,6 +1,12 @@
 use reqwest;
 use serde_json::{json, Value};
 
+const ORE_ADDRESSES: [&str; 3] = [
+  "oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ",
+  "2oLNTQKRb4a2117kFi6BYTUDu3RPrMVAHFhCfPKMosxX",
+  "5HngGmYzvSuh3XyU11brHDpMTHXQQRQQT4udGFtQSjgR"
+];
+
 pub async fn get_priority_fee_estimate(
     dynamic_fee_rpc_url: &str,
     dynamic_fee_strategy: &str,
@@ -27,7 +33,7 @@ pub async fn get_priority_fee_estimate(
             "id": "priority-fee-estimate",
             "method": "getRecentPrioritizationFees",
             "params": [
-                ["oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ"],
+              ORE_ADDRESSES,
                 {
                     "percentile": 5000,
                 }
@@ -40,7 +46,7 @@ pub async fn get_priority_fee_estimate(
             "id": "priority-fee-estimate",
             "method": "getPriorityFeeEstimate",
             "params": [{
-                "accountKeys": ["oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ"],
+                "accountKeys": ORE_ADDRESSES,
                 "options": {
                     "recommended": true
                 }

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -1,33 +1,73 @@
 use reqwest;
 use serde_json::{json, Value};
 
-pub async fn get_priority_fee_estimate(dynamic_fee_rpc_url: &str) -> Result<u64, Box<dyn std::error::Error>> {
+pub async fn get_priority_fee_estimate(
+    dynamic_fee_rpc_url: &str,
+) -> Result<u64, Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
-    let helius_url = dynamic_fee_rpc_url;
 
-    let body = json!({
-        "jsonrpc": "2.0",
-        "id": "helius-test",
-        "method": "getPriorityFeeEstimate",
-        "params": [{
-            "accountKeys": ["oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ"],
-            "options": {
-                "recommended": true
-            }
-        }]
-    });
+    let result_spec;
+
+    if dynamic_fee_rpc_url.contains("helius") {
+      result_spec = "helius"
+    } else if dynamic_fee_rpc_url.contains("triton") {
+      result_spec = "triton_one"
+    } else {
+      result_spec = "helius"
+    }
 
 
-    let response: Value = client.post(helius_url)
+    let body;
+
+    if result_spec == "triton_one" {
+        // Use the improved priority fees API
+        body = json!({
+            "jsonrpc": "2.0",
+            "id": "triton-test",
+            "method": "getRecentPrioritizationFees",
+            "params": [
+                "oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ",
+                {
+                    "percentile": 8000,
+                }
+            ]
+        })
+    } else {
+        // Use the current implementation (Helius API)
+        body = json!({
+            "jsonrpc": "2.0",
+            "id": "helius-test",
+            "method": "getPriorityFeeEstimate",
+            "params": [{
+                "accountKeys": ["oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ"],
+                "options": {
+                    "recommended": true
+                }
+            }]
+        })
+    };
+
+    let response: Value = client.post(dynamic_fee_rpc_url)
         .json(&body)
         .send()
         .await?
         .json()
         .await?;
 
-    let priority_fee = response["result"]["priorityFeeEstimate"]
-        .as_f64()
-        .ok_or_else(|| format!("Failed to parse priority fee. Response: {:?}", response))?;
+    let priority_fee = if result_spec == "triton_one" {
+        // Parse the improved priority fees API response
+        response["result"]
+            .as_array()
+            .and_then(|arr| arr.last())
+            .and_then(|last| last["prioritizationFee"].as_u64())
+            .ok_or_else(|| format!("Failed to parse priority fee. Response: {:?}", response))?
+    } else {
+        // Parse the current implementation response
+        response["result"]["priorityFeeEstimate"]
+            .as_f64()
+            .map(|fee| fee as u64)
+            .ok_or_else(|| format!("Failed to parse priority fee. Response: {:?}", response))?
+    };
 
-    Ok(priority_fee as u64)
+    Ok(priority_fee)
 }

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -1,11 +1,6 @@
 use reqwest;
 use serde_json::{json, Value};
-
-const ORE_ADDRESSES: [&str; 3] = [
-  "oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ",
-  "2oLNTQKRb4a2117kFi6BYTUDu3RPrMVAHFhCfPKMosxX",
-  "5HngGmYzvSuh3XyU11brHDpMTHXQQRQQT4udGFtQSjgR"
-];
+use ore_api::consts::BUS_ADDRESSES;
 
 pub async fn get_priority_fee_estimate(
     dynamic_fee_rpc_url: &str,
@@ -14,6 +9,10 @@ pub async fn get_priority_fee_estimate(
     let client = reqwest::Client::new();
 
     let result_spec;
+
+    let ore_addresses: Vec<String> = std::iter::once("oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ".to_string())
+        .chain(BUS_ADDRESSES.iter().map(|pubkey| pubkey.to_string()))
+        .collect();
 
     if dynamic_fee_strategy == "helius" {
       result_spec = "helius"
@@ -33,7 +32,7 @@ pub async fn get_priority_fee_estimate(
             "id": "priority-fee-estimate",
             "method": "getRecentPrioritizationFees",
             "params": [
-              ORE_ADDRESSES,
+              ore_addresses,
                 {
                     "percentile": 5000,
                 }
@@ -46,7 +45,7 @@ pub async fn get_priority_fee_estimate(
             "id": "priority-fee-estimate",
             "method": "getPriorityFeeEstimate",
             "params": [{
-                "accountKeys": ORE_ADDRESSES,
+                "accountKeys": ore_addresses,
                 "options": {
                     "recommended": true
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ struct Miner {
     pub priority_fee: Option<u64>,
     pub dynamic_fee_url: Option<String>,
     pub dynamic_fee_strategy: Option<String>,
+    pub dynamic_fee_max: Option<u64>,
     pub rpc_client: Arc<RpcClient>,
 }
 
@@ -111,7 +112,7 @@ struct Args {
 
     #[arg(
         long,
-        value_name = "DYNAMIC_FEE_RPC_URL",
+        value_name = "DYNAMIC_FEE_URL",
         help = "RPC URL to use for dynamic fee estimation. If set will enable dynamic fee pricing instead of static priority fee pricing.",
         global = true
     )]
@@ -125,6 +126,15 @@ struct Args {
         global = true
     )]
     dynamic_fee_strategy: Option<String>,
+    #[arg(
+        long,
+        value_name = "DYNAMIC_FEE_MAX",
+        help = "Maximum priority fee to use for dynamic fee estimation.",
+        default_value = "500000",
+        global = true
+    )]
+    dynamic_fee_max: Option<u64>,
+    
 
     #[command(subcommand)]
     command: Commands,
@@ -157,6 +167,7 @@ async fn main() {
         Some(default_keypair),
         args.dynamic_fee_url,
         args.dynamic_fee_strategy,
+        args.dynamic_fee_max,
     ));
 
     // Execute user command.
@@ -205,6 +216,7 @@ impl Miner {
         keypair_filepath: Option<String>,
         dynamic_fee_url: Option<String>,
         dynamic_fee_strategy: Option<String>,
+        dynamic_fee_max: Option<u64>,
     ) -> Self {
         Self {
             rpc_client,
@@ -212,6 +224,7 @@ impl Miner {
             priority_fee,
             dynamic_fee_url,
             dynamic_fee_strategy,
+            dynamic_fee_max,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use solana_sdk::{
 struct Miner {
     pub keypair_filepath: Option<String>,
     pub priority_fee: Option<u64>,
-    pub dynamic_fee_rpc_url: Option<String>,
+    pub dynamic_fee_url: Option<String>,
+    pub dynamic_fee_strategy: Option<String>,
     pub rpc_client: Arc<RpcClient>,
 }
 
@@ -114,7 +115,16 @@ struct Args {
         help = "RPC URL to use for dynamic fee estimation. If set will enable dynamic fee pricing instead of static priority fee pricing.",
         global = true
     )]
-    dynamic_fee_rpc_url: Option<String>,
+    dynamic_fee_url: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "DYNAMIC_FEE_STRATEGY",
+        help = "Strategy to use for dynamic fee estimation. Must be one of 'helius', or 'rpcpool'.",
+        default_value = "helius",
+        global = true
+    )]
+    dynamic_fee_strategy: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -145,7 +155,8 @@ async fn main() {
         Arc::new(rpc_client),
         args.priority_fee,
         Some(default_keypair),
-        args.dynamic_fee_rpc_url,
+        args.dynamic_fee_url,
+        args.dynamic_fee_strategy,
     ));
 
     // Execute user command.
@@ -192,13 +203,15 @@ impl Miner {
         rpc_client: Arc<RpcClient>,
         priority_fee: Option<u64>,
         keypair_filepath: Option<String>,
-        dynamic_fee_rpc_url: Option<String>,
+        dynamic_fee_url: Option<String>,
+        dynamic_fee_strategy: Option<String>,
     ) -> Self {
         Self {
             rpc_client,
             keypair_filepath,
             priority_fee,
-            dynamic_fee_rpc_url,
+            dynamic_fee_url,
+            dynamic_fee_strategy,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod send_and_confirm;
 mod stake;
 mod upgrade;
 mod utils;
+mod dynamic_fee;
 
 use std::sync::Arc;
 
@@ -28,7 +29,8 @@ use solana_sdk::{
 
 struct Miner {
     pub keypair_filepath: Option<String>,
-    pub priority_fee: u64,
+    pub priority_fee: Option<u64>,
+    pub dynamic_fee_rpc_url: Option<String>,
     pub rpc_client: Arc<RpcClient>,
 }
 
@@ -104,7 +106,15 @@ struct Args {
         default_value = "0",
         global = true
     )]
-    priority_fee: u64,
+    priority_fee: Option<u64>,
+
+    #[arg(
+        long,
+        value_name = "DYNAMIC_FEE_RPC_URL",
+        help = "RPC URL to use for dynamic fee estimation. If set will enable dynamic fee pricing instead of static priority fee pricing.",
+        global = true
+    )]
+    dynamic_fee_rpc_url: Option<String>,
 
     #[command(subcommand)]
     command: Commands,
@@ -135,6 +145,7 @@ async fn main() {
         Arc::new(rpc_client),
         args.priority_fee,
         Some(default_keypair),
+        args.dynamic_fee_rpc_url,
     ));
 
     // Execute user command.
@@ -179,13 +190,15 @@ async fn main() {
 impl Miner {
     pub fn new(
         rpc_client: Arc<RpcClient>,
-        priority_fee: u64,
+        priority_fee: Option<u64>,
         keypair_filepath: Option<String>,
+        dynamic_fee_rpc_url: Option<String>,
     ) -> Self {
         Self {
             rpc_client,
             keypair_filepath,
             priority_fee,
+            dynamic_fee_rpc_url,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ struct Args {
     #[arg(
         long,
         value_name = "DYNAMIC_FEE_STRATEGY",
-        help = "Strategy to use for dynamic fee estimation. Must be one of 'helius', or 'rpcpool'.",
+        help = "Strategy to use for dynamic fee estimation. Must be one of 'helius', or 'triton'.",
         default_value = "helius",
         global = true
     )]

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -81,7 +81,6 @@ impl Miner {
 
         final_ixs.push(ComputeBudgetInstruction::set_compute_unit_price(priority_fee));
         final_ixs.extend_from_slice(ixs);
-        final_ixs.extend_from_slice(ixs);
 
         // Build tx
         let send_cfg = RpcSendTransactionConfig {

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -72,8 +72,11 @@ impl Miner {
 
         let mut priority_fee = self.priority_fee.unwrap_or(0);
 
-        if let Some(dynamic_fee_rpc_url) = &self.dynamic_fee_rpc_url {
-            priority_fee = dynamic_fee::get_priority_fee_estimate(dynamic_fee_rpc_url).await.unwrap();
+        if let Some(dynamic_fee_url) = &self.dynamic_fee_url {
+            priority_fee = dynamic_fee::get_priority_fee_estimate(
+                dynamic_fee_url, 
+                self.dynamic_fee_strategy.as_ref().unwrap()
+            ).await.unwrap();  
         }
 
         final_ixs.push(ComputeBudgetInstruction::set_compute_unit_price(priority_fee));


### PR DESCRIPTION
This adds the configuration option `--dynamic-fee-url` and `--dynamic-fee-strategy` to support dynamic fees when submitting ORE mining transactions.

# Usage

Set `--dynamic-fee-url` to the RPC url of your provider with a priority fee API spec that is supported (see below).

# Optional Args
* `--dynamic-fee-max` -- Maximum amount of microlamports to pay for priority fee.
* `--dynamic-fee-strategy` - See Below

Enjoy automatically right-sized priority fees!

## Strategies

The value of `--dynamic-fee-strategy` should be one of the following, and the linked API spec will be used.

* `triton` - https://docs.triton.one/chains/solana/improved-priority-fees-api
* `helius` - https://docs.helius.dev/solana-rpc-nodes/priority-fee-api

If an option is not provided the strategy defaults to `helius`.