### PR TITLE
Add support for dynamic priority fees via alchemy

### DIFF
--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -19,7 +19,7 @@ impl Miner {
             .clone()
             .unwrap_or(self.rpc_client.url());
 
-        // Select fee estiamte strategy
+        // Select fee estimate strategy
         let host = Url::parse(&rpc_url)
             .unwrap()
             .host_str()
@@ -29,6 +29,8 @@ impl Miner {
             FeeStrategy::Helius
         } else if host.contains("rpcpool.com") {
             FeeStrategy::Triton
+        } else if host.contains("alchemy.com") {
+            FeeStrategy::Alchemy
         } else {
             return None;
         };

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -66,34 +66,42 @@ impl Miner {
                     .await
                     .unwrap();
 
-                let calculated_fee = match strategy.as_str() {
-                    "helius" => response["result"]["priorityFeeEstimate"]
-                        .as_f64()
-                        .map(|fee| fee as u64)
-                        .ok_or_else(|| {
-                            format!("Failed to parse priority fee. Response: {:?}", response)
-                        })
-                        .unwrap(),
-                    "triton" => response["result"]
-                        .as_array()
-                        .and_then(|arr| arr.last())
-                        .and_then(|last| last["prioritizationFee"].as_u64())
-                        .ok_or_else(|| {
-                            format!("Failed to parse priority fee. Response: {:?}", response)
-                        })
-                        .unwrap(),
-                    "alchemy" => response["result"]
-                        .as_array()
-                        .and_then(|arr|
-                        Some(arr.into_iter().map(|v| v["prioritizationFee"].as_u64().unwrap()).collect::<Vec<u64>>())
-                        )
-                        .and_then(|fees| Some((fees.iter().sum::<u64>() as f32 / fees.len() as f32).ceil() as u64))
-                        .ok_or_else(|| {
-                            format!("Failed to parse priority fee. Response: {:?}", response)
-                        })
-                        .unwrap(),
-                    _ => return self.priority_fee.unwrap_or(0),
-                };
+                let calculated_fee =
+                    match strategy.as_str() {
+                        "helius" => response["result"]["priorityFeeEstimate"]
+                            .as_f64()
+                            .map(|fee| fee as u64)
+                            .ok_or_else(|| {
+                                format!("Failed to parse priority fee. Response: {:?}", response)
+                            })
+                            .unwrap(),
+                        "triton" => response["result"]
+                            .as_array()
+                            .and_then(|arr| arr.last())
+                            .and_then(|last| last["prioritizationFee"].as_u64())
+                            .ok_or_else(|| {
+                                format!("Failed to parse priority fee. Response: {:?}", response)
+                            })
+                            .unwrap(),
+                        "alchemy" => response["result"]
+                            .as_array()
+                            .and_then(|arr| {
+                                Some(
+                                    arr.into_iter()
+                                        .map(|v| v["prioritizationFee"].as_u64().unwrap())
+                                        .collect::<Vec<u64>>(),
+                                )
+                            })
+                            .and_then(|fees| {
+                                Some((fees.iter().sum::<u64>() as f32 / fees.len() as f32).ceil()
+                                    as u64)
+                            })
+                            .ok_or_else(|| {
+                                format!("Failed to parse priority fee. Response: {:?}", response)
+                            })
+                            .unwrap(),
+                        _ => return self.priority_fee.unwrap_or(0),
+                    };
 
                 // Check if the calculated fee is higher than self.dynamic_fee_max
                 if let Some(max_fee) = self.dynamic_fee_max {

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -43,6 +43,16 @@ impl Miner {
                             ]
                         })
                     }
+                    "alchemy" => {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": "priority-fee-estimate",
+                            "method": "getRecentPrioritizationFees",
+                            "params": [
+                                ore_addresses,
+                            ]
+                        })
+                    }
                     _ => return self.priority_fee.unwrap_or(0),
                 };
 
@@ -68,6 +78,16 @@ impl Miner {
                         .as_array()
                         .and_then(|arr| arr.last())
                         .and_then(|last| last["prioritizationFee"].as_u64())
+                        .ok_or_else(|| {
+                            format!("Failed to parse priority fee. Response: {:?}", response)
+                        })
+                        .unwrap(),
+                    "alchemy" => response["result"]
+                        .as_array()
+                        .and_then(|arr|
+                        Some(arr.into_iter().map(|v| v["prioritizationFee"].as_u64().unwrap()).collect::<Vec<u64>>())
+                        )
+                        .and_then(|fees| Some((fees.iter().sum::<u64>() as f32 / fees.len() as f32).ceil() as u64))
                         .ok_or_else(|| {
                             format!("Failed to parse priority fee. Response: {:?}", response)
                         })


### PR DESCRIPTION
Adds support for alchemy's getRecentPrioritizationFees endpoint. It works mostly the same as triton's, except there isn't an option to get the average for us, so we do that manually.

Lines were getting a bit messy in the calculation logic after my changes so I ran rustfmt on the file as well.