### PR TITLE
Add Quicknode as a dynamic fee strategy

### DIFF
--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -43,6 +43,18 @@ impl Miner {
                             ]
                         })
                     }
+
+                    "quicknode" => {
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": 1, 
+                            "method": "qn_estimatePriorityFees",
+                            "params": {
+                                 "last_n_blocks": 100,
+                                 "account": "oreV2ZymfyeXgNgBdqMkumTqqAprVqgBWQfoYkrtKWQ",
+                             }
+                        })
+                    }
                     _ => return self.priority_fee.unwrap_or(0),
                 };
 
@@ -68,6 +80,13 @@ impl Miner {
                         .as_array()
                         .and_then(|arr| arr.last())
                         .and_then(|last| last["prioritizationFee"].as_u64())
+                        .ok_or_else(|| {
+                            format!("Failed to parse priority fee. Response: {:?}", response)
+                        })
+                        .unwrap(),
+                    "quicknode" => response["result"]["per_compute_unit"][self.dynamic_fee_priority.as_ref().unwrap()]
+                        .as_f64()
+                        .map(|fee| fee as u64)
                         .ok_or_else(|| {
                             format!("Failed to parse priority fee. Response: {:?}", response)
                         })

--- a/src/dynamic_fee.rs
+++ b/src/dynamic_fee.rs
@@ -47,7 +47,7 @@ impl Miner {
                     "quicknode" => {
                         json!({
                             "jsonrpc": "2.0",
-                            "id": 1, 
+                            "id": 1,
                             "method": "qn_estimatePriorityFees",
                             "params": {
                                  "last_n_blocks": 100,
@@ -84,13 +84,14 @@ impl Miner {
                             format!("Failed to parse priority fee. Response: {:?}", response)
                         })
                         .unwrap(),
-                    "quicknode" => response["result"]["per_compute_unit"][self.dynamic_fee_priority.as_ref().unwrap()]
-                        .as_f64()
-                        .map(|fee| fee as u64)
-                        .ok_or_else(|| {
-                            format!("Failed to parse priority fee. Response: {:?}", response)
-                        })
-                        .unwrap(),
+                    "quicknode" => response["result"]["per_compute_unit"]
+                        [self.dynamic_fee_priority.as_ref().unwrap()]
+                    .as_f64()
+                    .map(|fee| fee as u64)
+                    .ok_or_else(|| {
+                        format!("Failed to parse priority fee. Response: {:?}", response)
+                    })
+                    .unwrap(),
                     _ => return self.priority_fee.unwrap_or(0),
                 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod claim;
 mod close;
 mod config;
 mod cu_limits;
+mod dynamic_fee;
 #[cfg(feature = "admin")]
 mod initialize;
 mod mine;
@@ -15,7 +16,6 @@ mod send_and_confirm;
 mod stake;
 mod upgrade;
 mod utils;
-mod dynamic_fee;
 
 use std::sync::Arc;
 
@@ -152,7 +152,6 @@ struct Args {
         global = true
     )]
     dynamic_fee_priority: Option<String>,
-    
 
     #[command(subcommand)]
     command: Commands,
@@ -177,7 +176,9 @@ async fn main() {
     // Initialize miner.
     let cluster = args.rpc.unwrap_or(cli_config.json_rpc_url);
     let default_keypair = args.keypair.unwrap_or(cli_config.keypair_path.clone());
-    let fee_payer_filepath = args.fee_payer_filepath.unwrap_or(cli_config.keypair_path.clone());
+    let fee_payer_filepath = args
+        .fee_payer_filepath
+        .unwrap_or(cli_config.keypair_path.clone());
     let rpc_client = RpcClient::new_with_commitment(cluster, CommitmentConfig::confirmed());
 
     let miner = Arc::new(Miner::new(
@@ -249,7 +250,7 @@ impl Miner {
             dynamic_fee_strategy,
             dynamic_fee_priority,
             dynamic_fee_max,
-            fee_payer_filepath
+            fee_payer_filepath,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ struct Miner {
     pub priority_fee: Option<u64>,
     pub dynamic_fee_url: Option<String>,
     pub dynamic_fee_strategy: Option<String>,
+    pub dynamic_fee_priority: Option<String>,
     pub dynamic_fee_max: Option<u64>,
     pub rpc_client: Arc<RpcClient>,
     pub fee_payer_filepath: Option<String>,
@@ -130,7 +131,7 @@ struct Args {
     #[arg(
         long,
         value_name = "DYNAMIC_FEE_STRATEGY",
-        help = "Strategy to use for dynamic fee estimation. Must be one of 'helius', or 'triton'.",
+        help = "Strategy to use for dynamic fee estimation. Must be one of 'helius', 'triton', or 'quicknode'.",
         default_value = "helius",
         global = true
     )]
@@ -143,6 +144,14 @@ struct Args {
         global = true
     )]
     dynamic_fee_max: Option<u64>,
+    #[arg(
+        long,
+        value_name = "DYNAMIC_FEE_PRIORITY",
+        help = "Percentile for quicknode.  Ignored for other strategies. Must be one of extreme, high, medium, or low.  Maps to 95th, 80th, 60th, and 40th percentiles, respectively.",
+        default_value = "medium",
+        global = true
+    )]
+    dynamic_fee_priority: Option<String>,
     
 
     #[command(subcommand)]
@@ -177,6 +186,7 @@ async fn main() {
         Some(default_keypair),
         args.dynamic_fee_url,
         args.dynamic_fee_strategy,
+        args.dynamic_fee_priority,
         args.dynamic_fee_max,
         Some(fee_payer_filepath),
     ));
@@ -227,6 +237,7 @@ impl Miner {
         keypair_filepath: Option<String>,
         dynamic_fee_url: Option<String>,
         dynamic_fee_strategy: Option<String>,
+        dynamic_fee_priority: Option<String>,
         dynamic_fee_max: Option<u64>,
         fee_payer_filepath: Option<String>,
     ) -> Self {
@@ -236,6 +247,7 @@ impl Miner {
             priority_fee,
             dynamic_fee_url,
             dynamic_fee_strategy,
+            dynamic_fee_priority,
             dynamic_fee_max,
             fee_payer_filepath
         }

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -72,15 +72,13 @@ impl Miner {
         }
 
         let priority_fee = match &self.dynamic_fee_url {
-            Some(_) => {
-                self.dynamic_fee().await
-            }
-            None => {
-                self.priority_fee.unwrap_or(0)
-            }
+            Some(_) => self.dynamic_fee().await,
+            None => self.priority_fee.unwrap_or(0),
         };
 
-        final_ixs.push(ComputeBudgetInstruction::set_compute_unit_price(priority_fee));
+        final_ixs.push(ComputeBudgetInstruction::set_compute_unit_price(
+            priority_fee,
+        ));
         final_ixs.extend_from_slice(ixs);
 
         // Build tx
@@ -99,7 +97,6 @@ impl Miner {
             .await
             .unwrap();
 
-        
         if signer.pubkey() == fee_payer.pubkey() {
             tx.sign(&[&signer], hash);
         } else {
@@ -109,10 +106,17 @@ impl Miner {
         // Submit tx
         let mut attempts = 0;
         loop {
-
             let message = match &self.dynamic_fee_url {
-                Some(_) => format!("Submitting transaction... (attempt {} with dynamic priority fee of {} via {})", attempts, priority_fee, self.dynamic_fee_strategy.as_ref().unwrap()),
-                None => format!("Submitting transaction... (attempt {} with static priority fee of {})", attempts, priority_fee),
+                Some(_) => format!(
+                    "Submitting transaction... (attempt {} with dynamic priority fee of {} via {})",
+                    attempts,
+                    priority_fee,
+                    self.dynamic_fee_strategy.as_ref().unwrap()
+                ),
+                None => format!(
+                    "Submitting transaction... (attempt {} with static priority fee of {})",
+                    attempts, priority_fee
+                ),
             };
 
             progress_bar.set_message(message);


### PR DESCRIPTION
```
  Best hash: 11aE3wo6T3sjMdh8qf2ee5PEh79TvBTmbXazVfavCxB (difficulty: 16)
⠲ Submitting transaction... (attempt 7 with dynamic priority fee of 100000 via quicknode)            
```

Adds [quicknode's estimate priority fees](https://www.quicknode.com/docs/solana/qn_estimatePriorityFees) as a dynamic fee strategy.

The API reponds with four "named" percentiles for fees, and so this also adds that as another flag: `--dynamic-fee-priority`.  Per Quicknode's documentation:

>It provides estimates for priority fees (in microlamports) based on per-compute-unit metrics
extreme integer
Fee estimate for extreme priority per compute unit (95th percentile)
high integer
Fee estimate for high priority per compute unit (80th percentile)
medium integer
Fee estimate for medium priority per compute unit (60th percentile)
low integer
Fee estimate for low priority per compute unit (40th percentile)

Default is set to "medium"

Tested with "high" as well.

The flag is ignored for other strategies.