### PR TITLE
fix(send_and_confirm): Implement Retries for Latest Blockhash Query

### DIFF
--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -18,6 +18,7 @@ use solana_sdk::{
 };
 use solana_transaction_status::{TransactionConfirmationStatus, UiTransactionEncoding};
 
+use crate::ore_utils::get_latest_blockhash_with_retries;
 use crate::Miner;
 
 const MIN_SOL_BALANCE: f64 = 0.005;
@@ -92,10 +93,7 @@ impl Miner {
         let mut tx = Transaction::new_with_payer(&final_ixs, Some(&fee_payer.pubkey()));
 
         // Sign tx
-        let (hash, _slot) = client
-            .get_latest_blockhash_with_commitment(self.rpc_client.commitment())
-            .await
-            .unwrap();
+        let (hash, _slot) = get_latest_blockhash_with_retries(&client).await?;
 
         if signer.pubkey() == fee_payer.pubkey() {
             tx.sign(&[&signer], hash);

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -106,10 +106,8 @@ impl Miner {
                 }
 
                 // Resign the tx
-                let (hash, _slot) = client
-                    .get_latest_blockhash_with_commitment(self.rpc_client.commitment())
-                    .await
-                    .unwrap();
+                let (hash, _slot) = get_latest_blockhash_with_retries(client)
+                    .await?;
                 if signer.pubkey() == fee_payer.pubkey() {
                     tx.sign(&[&signer], hash);
                 } else {

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -89,14 +89,6 @@ impl Miner {
         };
         let mut tx = Transaction::new_with_payer(&final_ixs, Some(&fee_payer.pubkey()));
 
-        // Sign tx
-        let (hash, _slot) = get_latest_blockhash_with_retries(&client).await?;
-
-        if signer.pubkey() == fee_payer.pubkey() {
-            tx.sign(&[&signer], hash);
-        } else {
-            tx.sign(&[&signer, &fee_payer], hash);
-        }
         // Submit tx
         let progress_bar = spinner::new_progress_bar();
         let mut attempts = 0;

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -18,7 +18,7 @@ use solana_sdk::{
 };
 use solana_transaction_status::{TransactionConfirmationStatus, UiTransactionEncoding};
 
-use crate::ore_utils::get_latest_blockhash_with_retries;
+use crate::utils::get_latest_blockhash_with_retries;
 use crate::Miner;
 
 const MIN_SOL_BALANCE: f64 = 0.005;

--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -106,8 +106,7 @@ impl Miner {
                 }
 
                 // Resign the tx
-                let (hash, _slot) = get_latest_blockhash_with_retries(client)
-                    .await?;
+                let (hash, _slot) = get_latest_blockhash_with_retries(client).await?;
                 if signer.pubkey() == fee_payer.pubkey() {
                     tx.sign(&[&signer], hash);
                 } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,8 @@ use solana_program::{pubkey::Pubkey, sysvar};
 use solana_rpc_client::spinner;
 use solana_sdk::{clock::Clock, hash::Hash};
 use spl_associated_token_account::get_associated_token_address;
-use std::time;
+use std::time::Duration;
+use tokio::time::sleep;
 
 pub const BLOCKHASH_QUERY_RETRIES: usize = 5;
 pub const BLOCKHASH_QUERY_DELAY: u64 = 500;
@@ -119,7 +120,7 @@ pub async fn get_latest_blockhash_with_retries(
         }
 
         // Retry
-        time::sleep(time::Duration::from_millis(BLOCKHASH_QUERY_DELAY)).await;
+        sleep(Duration::from_millis(BLOCKHASH_QUERY_DELAY)).await;
         attempts += 1;
 
         if attempts >= BLOCKHASH_QUERY_RETRIES {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 
 use cached::proc_macro::cached;
+use colored::*;
 use ore_api::{
     consts::{
         CONFIG_ADDRESS, MINT_ADDRESS, PROOF, TOKEN_DECIMALS, TOKEN_DECIMALS_V1, TREASURY_ADDRESS,
@@ -8,10 +9,16 @@ use ore_api::{
     state::{Config, Proof, Treasury},
 };
 use ore_utils::AccountDeserialize;
+use solana_client::client_error::{ClientError, ClientErrorKind};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::{pubkey::Pubkey, sysvar};
-use solana_sdk::clock::Clock;
+use solana_rpc_client::spinner;
+use solana_sdk::{clock::Clock, hash::Hash};
 use spl_associated_token_account::get_associated_token_address;
+use std::time;
+
+pub const BLOCKHASH_QUERY_RETRIES: usize = 5;
+pub const BLOCKHASH_QUERY_DELAY: u64 = 500;
 
 pub async fn _get_treasury(client: &RpcClient) -> Treasury {
     let data = client
@@ -75,6 +82,58 @@ pub fn ask_confirm(question: &str) -> bool {
             'y' | 'Y' => return true,
             'n' | 'N' => return false,
             _ => println!("y/n only please."),
+        }
+    }
+}
+
+pub async fn get_latest_blockhash_with_retries(
+    client: &RpcClient,
+) -> Result<(Hash, u64), ClientError> {
+    let progress_bar = spinner::new_progress_bar();
+    let mut attempts = 0;
+
+    loop {
+        progress_bar.set_message(format!(
+            "Fetching latest blockhash... (attempt {})",
+            attempts + 1
+        ));
+
+        match client
+            .get_latest_blockhash_with_commitment(client.commitment())
+            .await
+        {
+            Ok((hash, slot)) => {
+                progress_bar.finish_with_message(format!(
+                    "{}: Latest blockhash fetched",
+                    "OK".bold().green()
+                ));
+                return Ok((hash, slot));
+            }
+            Err(err) => {
+                progress_bar.set_message(format!(
+                    "{}: {}",
+                    "ERROR".bold().red(),
+                    err.kind().to_string(),
+                ));
+            }
+        }
+
+        // Retry
+        time::sleep(time::Duration::from_millis(BLOCKHASH_QUERY_DELAY)).await;
+        attempts += 1;
+
+        if attempts >= BLOCKHASH_QUERY_RETRIES {
+            progress_bar.finish_with_message(format!(
+                "{}: Max retries reached for latest blockhash query",
+                "ERROR".bold().red()
+            ));
+
+            return Err(ClientError {
+                request: None,
+                kind: ClientErrorKind::Custom(
+                    "Max retries reached for latest blockhash query".into(),
+                ),
+            });
         }
     }
 }


### PR DESCRIPTION
Currently, we `await` and `unwrap` on the `get_latest_blockhash_with_commitment` RPC call, which could cause the CLI to panic. Within the context of mining, this can cause a user to lose out on successfully mining a hash, as they'd have to restart the CLI and begin the mining process from scratch

This PR aims to implement retries for the latest blockhash query in `send_and_confirm.rs` to help alleviate potential, transient RPC issues that could cause this call to fail and unduly punish the user

cc @HardhatChad ⛏️ 