### PR TITLE
Use Tokio Sleep Instead Of Std Sleep

### DIFF
--- a/src/send_and_confirm.rs
+++ b/src/send_and_confirm.rs
@@ -174,7 +174,7 @@ impl Miner {
 
                     // Confirm transaction
                     'confirm: for _ in 0..CONFIRM_RETRIES {
-                        std::thread::sleep(Duration::from_millis(CONFIRM_DELAY));
+                        tokio::time::sleep(Duration::from_millis(CONFIRM_DELAY)).await;
                         match client.get_signature_statuses(&[sig]).await {
                             Ok(signature_statuses) => {
                                 for status in signature_statuses.value {
@@ -264,7 +264,7 @@ impl Miner {
             }
 
             // Retry
-            std::thread::sleep(Duration::from_millis(GATEWAY_DELAY));
+            tokio::time::sleep(Duration::from_millis(GATEWAY_DELAY)).await;
             if attempts > GATEWAY_RETRIES {
                 log_error(&progress_bar, "Max retries", true);
                 return Err(ClientError {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ pub async fn get_updated_proof_with_authority(
         if proof.last_hash_at.gt(&lash_hash_at) {
             return proof;
         }
-        std::thread::sleep(Duration::from_millis(1000));
+        tokio::time::sleep(Duration::from_millis(1_000)).await;
     }
 }
 


### PR DESCRIPTION
# Overview

Usage of `std::thread::sleep` is discouraged when using tokio, as it can block entire OS threads, external resources on this:

* https://users.rust-lang.org/t/async-await-and-multi-thread-tokio-runtime/110107/3
* https://stackoverflow.com/questions/75746205/stdthreadsleep-inside-a-busy-loop-within-asynchronous-methods