### PR TITLE
Adds proof_authority arg to mine command

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -69,6 +69,13 @@ pub struct MineArgs {
         default_value = "5"
     )]
     pub buffer_time: u64,
+
+    #[arg(
+        long,
+        value_name = "PROOF_AUTHORITY",
+        help = "Authority of the Proof to mine for, if different from signer keypair."
+    )]
+    pub proof_authority: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/open.rs
+++ b/src/open.rs
@@ -1,13 +1,14 @@
+use solana_program::pubkey::Pubkey;
 use solana_sdk::signature::Signer;
 
 use crate::{send_and_confirm::ComputeBudget, utils::proof_pubkey, Miner};
 
 impl Miner {
-    pub async fn open(&self) {
+    pub async fn open(&self, proof_authority: Pubkey) {
         // Return early if miner is already registered
         let signer = self.signer();
         let fee_payer = self.fee_payer();
-        let proof_address = proof_pubkey(signer.pubkey());
+        let proof_address = proof_pubkey(proof_authority);
         if self.rpc_client.get_account(&proof_address).await.is_ok() {
             return;
         }


### PR DESCRIPTION
Adds `proof_authority` arg to `mine` command to allow mining on a Proof account owned by a different signer.