### PR TITLE
Integration with Mining Pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "2.1.8"
+version = "2.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c67c8c00902d0cb31d7e1bdcc6caf81c80e4a1f11ca48054eb609e41b6065b4"
+checksum = "26f004e50a7fba301eb53caa4f8ce772c1a512f314de64cff580f90fb1dff8d1"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2787,6 +2787,7 @@ dependencies = [
  "indicatif",
  "num_cpus",
  "ore-api",
+ "ore-pool-api",
  "ore-utils",
  "rand 0.8.5",
  "reqwest 0.12.4",
@@ -2808,10 +2809,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ore-pool-api"
+version = "0.0.1"
+dependencies = [
+ "array-const-fn-init",
+ "bytemuck",
+ "const-crypto",
+ "drillx",
+ "mpl-token-metadata",
+ "num_enum 0.7.2",
+ "ore-api",
+ "ore-utils",
+ "solana-program",
+ "spl-associated-token-account",
+ "spl-token",
+ "static_assertions",
+ "thiserror",
+]
+
+[[package]]
 name = "ore-utils"
-version = "2.1.8"
+version = "2.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c92cb0b8a4c9583113b78c87a5372d71825ec3432402cb843e1ffc6af9f6b7d"
+checksum = "7a2d6933b14c84fb91ad7ab2e8fccff589884a81507c1a198dea4f03f3180ef4"
 dependencies = [
  "bytemuck",
  "solana-program",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "solana-transaction-status",
  "spl-associated-token-account",
  "spl-token",
+ "thiserror",
  "tokio",
  "tokio-tungstenite 0.16.1",
  "types",
@@ -4971,18 +4972,18 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1832,6 +1832,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2664,7 +2667,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.70",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -1832,9 +1832,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2667,7 +2664,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.70",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1832,6 +1832,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2664,7 +2667,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.70",
@@ -2802,6 +2805,7 @@ dependencies = [
  "spl-token",
  "tokio",
  "tokio-tungstenite 0.16.1",
+ "types",
  "url",
 ]
 
@@ -5298,6 +5302,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "types"
+version = "0.0.1"
+dependencies = [
+ "drillx",
+ "serde",
+ "solana-sdk",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ indicatif = "0.17.8"
 num_cpus = "1.16.0"
 ore-api = "2.1.8"
 ore-utils = "2.1.8"
+ore-pool-api = { path = "../ore-pool/api" }
+ore-pool-types = { path = "../ore-pool/types", package = "types" }
 rand = "0.8.4"
 reqwest = { version = "0.12", features = ["json"] }
 solana-cli-config = "^1.18"
@@ -47,7 +49,6 @@ spl-associated-token-account = { version = "^2.3", features = [
   "no-entrypoint",
 ] }
 tokio = "1.35.1"
-ore-pool-types = { path = "../ore-pool/types", package = "types" }
 url = "2.5"
 tokio-tungstenite = "0.16"
 serde = { version = "1.0", features = ["derive"] }
@@ -70,4 +71,3 @@ overflow-checks = false
 
 [build]
 rustflags = ["-C", "target-cpu=native"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ore-pool-types = { path = "../ore-pool/types", package = "types" }
 url = "2.5"
 tokio-tungstenite = "0.16"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.63"
 
 # [patch.crates-io]
 # drillx = { path = "../drillx/drillx" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cached = "0.46.1"
 chrono = "0.4.38"
 clap = { version = "4.4.12", features = ["derive"] }
 colored = "2.0"
-core_affinity = "0.8.1" 
+core_affinity = "0.8.1"
 drillx = "2.1.0"
 futures = "0.3.30"
 indicatif = "0.17.8"
@@ -47,6 +47,7 @@ spl-associated-token-account = { version = "^2.3", features = [
   "no-entrypoint",
 ] }
 tokio = "1.35.1"
+ore-pool-types = { path = "../ore-pool/types", package = "types" }
 url = "2.5"
 tokio-tungstenite = "0.16"
 serde = { version = "1.0", features = ["derive"] }
@@ -57,14 +58,15 @@ serde = { version = "1.0", features = ["derive"] }
 # ore-utils = { path = "../ore/utils" }
 
 [profile.release]
-opt-level = 3   # Optimize for binary size. You can use "3" for full optimizations if binary size isn't an issue.
-codegen-units = 1 # Better optimization with fewer codegen units
-lto = true        # Enable Link Time Optimization (LTO)
-debug = false     # Disable debug info to reduce binary size
-panic = 'abort'   # Reduces the binary size further by not including unwinding information
+opt-level = 3           # Optimize for binary size. You can use "3" for full optimizations if binary size isn't an issue.
+codegen-units = 1       # Better optimization with fewer codegen units
+lto = true              # Enable Link Time Optimization (LTO)
+debug = false           # Disable debug info to reduce binary size
+panic = 'abort'         # Reduces the binary size further by not including unwinding information
 rpath = false
 incremental = false
 overflow-checks = false
 
 [build]
 rustflags = ["-C", "target-cpu=native"]
+

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,6 +38,14 @@ pub struct ClaimArgs {
         help = "Wallet address to receive claimed tokens."
     )]
     pub to: Option<String>,
+
+    #[arg(
+        long,
+        short,
+        value_name = "POOL_URL",
+        help = "The optional pool url to claim rewards from."
+    )]
+    pub pool_url: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -69,6 +77,14 @@ pub struct MineArgs {
         default_value = "5"
     )]
     pub buffer_time: u64,
+
+    #[arg(
+        long,
+        short,
+        value_name = "POOL_URL",
+        help = "The optional pool url to join and forward solutions to."
+    )]
+    pub pool_url: Option<String>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -22,8 +22,7 @@ impl Miner {
     ) -> Result<(), crate::error::Error> {
         match pool_url {
             Some(pool_url) => {
-                let sig = self.claim_from_pool(args).await?;
-                println!("{:?}", sig);
+                let _ = self.claim_from_pool(args).await?;
                 Ok(())
             }
             None => {

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -21,7 +21,7 @@ impl Miner {
         pool_url: Option<String>,
     ) -> Result<(), crate::error::Error> {
         match pool_url {
-            Some(pool_url) => {
+            Some(_pool_url) => {
                 let _ = self.claim_from_pool(args).await?;
                 Ok(())
             }

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use colored::*;
 use ore_api::consts::MINT_ADDRESS;
 use solana_program::pubkey::Pubkey;
-use solana_sdk::signature::Signer;
+use solana_sdk::signature::{Signature, Signer};
 use spl_token::amount_to_ui_amount;
 
 use crate::{
@@ -15,7 +15,25 @@ use crate::{
 };
 
 impl Miner {
-    pub async fn claim(&self, args: ClaimArgs) {
+    pub async fn claim(
+        &self,
+        args: ClaimArgs,
+        pool_url: Option<String>,
+    ) -> Result<(), crate::error::Error> {
+        match pool_url {
+            Some(pool_url) => {
+                let sig = self.claim_from_pool(args).await?;
+                println!("{:?}", sig);
+                Ok(())
+            }
+            None => {
+                self.claim_from_proof(args).await;
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn claim_from_proof(&self, args: ClaimArgs) {
         let signer = self.signer();
         let pubkey = signer.pubkey();
         let proof = get_proof_with_authority(&self.rpc_client, pubkey).await;
@@ -75,6 +93,74 @@ impl Miner {
         self.send_and_confirm(&ixs, ComputeBudget::Fixed(CU_LIMIT_CLAIM), false)
             .await
             .ok();
+    }
+
+    async fn claim_from_pool(&self, args: ClaimArgs) -> Result<Signature, crate::error::Error> {
+        let http_client = &reqwest::Client::new();
+        let pool_address = self.get_pool_address(http_client).await?;
+        let member = self.get_pool_member_onchain(pool_address.address).await?;
+        let mut ixs = vec![];
+        let beneficiary = match args.to {
+            None => self.initialize_ata(self.signer().pubkey()).await,
+            Some(to) => {
+                // Create beneficiary token account, if needed
+                let wallet = Pubkey::from_str(&to).expect("Failed to parse wallet address");
+                let benefiary_tokens = spl_associated_token_account::get_associated_token_address(
+                    &wallet,
+                    &MINT_ADDRESS,
+                );
+                if self
+                    .rpc_client
+                    .get_token_account(&benefiary_tokens)
+                    .await
+                    .is_err()
+                {
+                    ixs.push(
+                        spl_associated_token_account::instruction::create_associated_token_account(
+                            &self.signer().pubkey(),
+                            &wallet,
+                            &ore_api::consts::MINT_ADDRESS,
+                            &spl_token::id(),
+                        ),
+                    );
+                }
+                benefiary_tokens
+            }
+        };
+
+        // Parse amount to claim
+        let amount = if let Some(amount) = args.amount {
+            amount_f64_to_u64(amount)
+        } else {
+            member.balance
+        };
+
+        // Confirm user wants to claim
+        if !ask_confirm(
+            format!(
+                "\nYou are about to claim {}.\n\nAre you sure you want to continue? [Y/n]",
+                format!(
+                    "{} ORE",
+                    amount_to_ui_amount(amount, ore_api::consts::TOKEN_DECIMALS)
+                )
+                .bold(),
+            )
+            .as_str(),
+        ) {
+            return Err(crate::error::Error::Internal("exited claim".to_string()));
+        }
+
+        // Send and confirm
+        ixs.push(ore_pool_api::instruction::claim(
+            self.signer().pubkey(),
+            beneficiary,
+            pool_address.address,
+            pool_address.bump,
+            amount,
+        ));
+        self.send_and_confirm(&ixs, ComputeBudget::Fixed(50_000), false)
+            .await
+            .map_err(From::from)
     }
 
     async fn initialize_ata(&self, wallet: Pubkey) -> Pubkey {

--- a/src/close.rs
+++ b/src/close.rs
@@ -28,7 +28,7 @@ impl Miner {
 
         // Claim stake
         if proof.balance.gt(&0) {
-            self.claim(ClaimArgs {
+            self.claim_from_proof(ClaimArgs {
                 amount: None,
                 to: None,
             })

--- a/src/close.rs
+++ b/src/close.rs
@@ -31,6 +31,7 @@ impl Miner {
             self.claim_from_proof(ClaimArgs {
                 amount: None,
                 to: None,
+                pool_url: None,
             })
             .await;
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,4 +4,8 @@ pub enum Error {
     Internal(String),
     #[error("reqwest")]
     Reqwest(#[from] reqwest::Error),
+    #[error("solana rpc client")]
+    SolanaRpcClient(#[from] solana_client::client_error::ClientError),
+    #[error("solana program")]
+    SolanaProgram(#[from] solana_program::program_error::ProgramError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Internal(String),
+    #[error("reqwest")]
+    Reqwest(#[from] reqwest::Error),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,8 @@ struct Args {
     #[arg(
         long,
         value_name = "POOL",
-        help = "Join a Mining Pool of your choice. Defaults to false."
+        help = "Join a Mining Pool of your choice. Defaults to false.",
+        global = true
     )]
     pool: bool,
 
@@ -253,7 +254,9 @@ async fn main() {
         }
         Commands::Mine(mine_args) => match args.pool {
             true => {
-                let _ = miner.mine_pool(mine_args).await;
+                if let Err(err) = miner.mine_pool(mine_args).await {
+                    println!("{}", format!("{:?}", err));
+                }
             }
             false => {
                 miner.mine(mine_args).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,14 +162,6 @@ struct Args {
     )]
     pool_url: Option<String>,
 
-    #[arg(
-        long,
-        value_name = "POOL",
-        help = "Join a Mining Pool of your choice. Defaults to false.",
-        global = true
-    )]
-    pool: bool,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -229,7 +221,7 @@ async fn main() {
         Some(fee_payer_filepath),
         Arc::new(jito_client),
         tip,
-        args.pool_url,
+        args.pool_url.clone(),
     ));
 
     // Execute user command.
@@ -252,16 +244,11 @@ async fn main() {
         Commands::Config(_) => {
             miner.config().await;
         }
-        Commands::Mine(mine_args) => match args.pool {
-            true => {
-                if let Err(err) = miner.mine_pool(mine_args).await {
-                    println!("{}", format!("{:?}", err));
-                }
+        Commands::Mine(mine_args) => {
+            if let Err(err) = miner.mine(mine_args, args.pool_url).await {
+                println!("{:?}", err);
             }
-            false => {
-                miner.mine(mine_args).await;
-            }
-        },
+        }
         Commands::Proof(args) => {
             miner.proof(args).await;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,8 @@ struct Miner {
     pub fee_payer_filepath: Option<String>,
     pub jito_client: Arc<RpcClient>,
     pub tip: Arc<std::sync::RwLock<u64>>,
+    pub pool: bool,
+    pub pool_url: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -151,6 +153,21 @@ struct Args {
     )]
     jito: bool,
 
+    #[arg(
+        long,
+        value_name = "POOL_URL",
+        help = "Mining Pool URL to forward solutions to.",
+        global = true
+    )]
+    pool_url: Option<String>,
+
+    #[arg(
+        long,
+        value_name = "POOL",
+        help = "Join a Mining Pool of your choice. Defaults to false."
+    )]
+    pool: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -210,6 +227,8 @@ async fn main() {
         Some(fee_payer_filepath),
         Arc::new(jito_client),
         tip,
+        args.pool,
+        args.pool_url,
     ));
 
     // Execute user command.
@@ -267,6 +286,8 @@ impl Miner {
         fee_payer_filepath: Option<String>,
         jito_client: Arc<RpcClient>,
         tip: Arc<std::sync::RwLock<u64>>,
+        pool: bool,
+        pool_url: Option<String>,
     ) -> Self {
         Self {
             rpc_client,
@@ -277,6 +298,8 @@ impl Miner {
             fee_payer_filepath,
             jito_client,
             tip,
+            pool,
+            pool_url,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,8 +235,10 @@ async fn main() {
         Commands::Busses(_) => {
             miner.busses().await;
         }
-        Commands::Claim(args) => {
-            miner.claim(args).await;
+        Commands::Claim(claim_args) => {
+            if let Err(err) = miner.claim(claim_args, args.pool_url).await {
+                println!("{:?}", err);
+            }
         }
         Commands::Close(_) => {
             miner.close().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,6 @@ struct Miner {
     pub fee_payer_filepath: Option<String>,
     pub jito_client: Arc<RpcClient>,
     pub tip: Arc<std::sync::RwLock<u64>>,
-    pub pool_url: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -154,14 +153,6 @@ struct Args {
     )]
     jito: bool,
 
-    #[arg(
-        long,
-        value_name = "POOL_URL",
-        help = "Mining Pool URL to forward solutions to.",
-        global = true
-    )]
-    pool_url: Option<String>,
-
     #[command(subcommand)]
     command: Commands,
 }
@@ -221,7 +212,6 @@ async fn main() {
         Some(fee_payer_filepath),
         Arc::new(jito_client),
         tip,
-        args.pool_url.clone(),
     ));
 
     // Execute user command.
@@ -235,8 +225,8 @@ async fn main() {
         Commands::Busses(_) => {
             miner.busses().await;
         }
-        Commands::Claim(claim_args) => {
-            if let Err(err) = miner.claim(claim_args, args.pool_url).await {
+        Commands::Claim(args) => {
+            if let Err(err) = miner.claim(args).await {
                 println!("{:?}", err);
             }
         }
@@ -246,8 +236,8 @@ async fn main() {
         Commands::Config(_) => {
             miner.config().await;
         }
-        Commands::Mine(mine_args) => {
-            if let Err(err) = miner.mine(mine_args, args.pool_url).await {
+        Commands::Mine(args) => {
+            if let Err(err) = miner.mine(args).await {
                 println!("{:?}", err);
             }
         }
@@ -283,7 +273,6 @@ impl Miner {
         fee_payer_filepath: Option<String>,
         jito_client: Arc<RpcClient>,
         tip: Arc<std::sync::RwLock<u64>>,
-        pool_url: Option<String>,
     ) -> Self {
         Self {
             rpc_client,
@@ -294,7 +283,6 @@ impl Miner {
             fee_payer_filepath,
             jito_client,
             tip,
-            pool_url,
         }
     }
 

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -111,6 +111,7 @@ impl Miner {
         let http_client = &reqwest::Client::new();
         // register, if needed
         let mut pool_member = self.post_pool_register(http_client).await?;
+        println!("{:?}", pool_member);
         let nonce_index = pool_member.id as u64;
         // Check num threads
         self.check_num_cores(args.cores);

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -30,7 +30,19 @@ use crate::{
 };
 
 impl Miner {
-    pub async fn mine(&self, args: MineArgs) {
+    pub async fn mine(&self, args: MineArgs, pool_url: Option<String>) -> Result<(), Error> {
+        match pool_url {
+            Some(_) => {
+                self.mine_pool(args).await?;
+            }
+            None => {
+                self.mine_solo(args).await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn mine_solo(&self, args: MineArgs) {
         // Open account, if needed.
         let signer = self.signer();
         self.open().await;
@@ -107,7 +119,7 @@ impl Miner {
         }
     }
 
-    pub async fn mine_pool(&self, args: MineArgs) -> Result<(), Error> {
+    async fn mine_pool(&self, args: MineArgs) -> Result<(), Error> {
         let http_client = &reqwest::Client::new();
         // register, if needed
         let mut pool_member = self.post_pool_register(http_client).await?;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -140,9 +140,7 @@ impl Miner {
             // Build nonce indices
             let u64_unit = u64::MAX.saturating_div(member_challenge.num_total_members);
             let left_bound = u64_unit.saturating_mul(nonce_index);
-            let right_bound = u64_unit.saturating_div(nonce_index);
-            let total_range = right_bound - left_bound + 1;
-            let range_per_core = total_range.saturating_div(args.cores);
+            let range_per_core = u64_unit.saturating_div(args.cores);
             let mut nonce_indices = Vec::with_capacity(args.cores as usize);
             for n in 0..(args.cores) {
                 let index = left_bound + n * range_per_core;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -139,9 +139,14 @@ impl Miner {
             // Compute cutoff time
             let cutoff_time = self.get_cutoff(last_hash_at, member_challenge.buffer).await;
             // Build nonce indices
+            println!("num members: {}", member_challenge.num_total_members);
             let u64_unit = u64::MAX.saturating_div(member_challenge.num_total_members);
+            println!("unit: {}", u64_unit);
             let left_bound = u64_unit.saturating_mul(nonce_index);
+            println!("left bound: {}", left_bound);
             let range_per_core = u64_unit.saturating_div(args.cores);
+            println!("cores: {}", args.cores);
+            println!("range per core: {}", range_per_core);
             let mut nonce_indices = Vec::with_capacity(args.cores as usize);
             for n in 0..(args.cores) {
                 let index = left_bound + n * range_per_core;
@@ -185,6 +190,7 @@ impl Miner {
                     let progress_bar = progress_bar.clone();
                     println!("{:?}", i);
                     let nonce = nonce_indices[i.id];
+                    println!("core nonce start: {}", nonce);
                     let mut memory = equix::SolverMemory::new();
                     move || {
                         // Pin to core
@@ -208,6 +214,7 @@ impl Miner {
                             for hx in hxs {
                                 let difficulty = hx.difficulty();
                                 if difficulty.gt(&best_difficulty) {
+                                    println!("new best nonce: {}", nonce);
                                     best_nonce = nonce;
                                     best_difficulty = difficulty;
                                     best_hash = hx;
@@ -277,6 +284,7 @@ impl Miner {
             best_difficulty
         ));
 
+        println!("final best nonce: {}", best_nonce);
         Solution::new(best_hash.d, best_nonce.to_le_bytes())
     }
 

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -119,6 +119,7 @@ impl Miner {
             let member_challenge = self
                 .get_updated_pool_challenge(http_client, last_hash_at)
                 .await?;
+            println!("member challenge: {:?}", member_challenge);
             last_hash_at = member_challenge.challenge.lash_hash_at;
             let cutoff_time = member_challenge.challenge.cutoff_time;
             // Build nonce indices
@@ -142,6 +143,7 @@ impl Miner {
                 nonce_indices.as_slice(),
             )
             .await;
+            println!("solution: {:?}", solution);
             // Post solution to operator
             self.post_pool_solution(http_client, &solution).await?;
         }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,64 @@
+use drillx::Solution;
+use ore_pool_types::{ContributePayload, MemberChallenge};
+use solana_sdk::{signature::Signature, signer::Signer};
+
+use crate::{error::Error, Miner};
+
+impl Miner {
+    pub async fn get_updated_pool_challenge(
+        &self,
+        http_client: &reqwest::Client,
+        last_hash_at: i64,
+    ) -> Result<MemberChallenge, Error> {
+        let mut retries = 0;
+        let max_retries = 10;
+        loop {
+            let challenge = self.get_pool_challenge(http_client).await?;
+            if challenge.challenge.lash_hash_at <= last_hash_at {
+                retries += 1;
+                if retries == max_retries {
+                    return Err(Error::Internal("could not fetch new challenge".to_string()));
+                }
+            } else {
+                return Ok(challenge);
+            }
+        }
+    }
+
+    async fn get_pool_challenge(
+        &self,
+        http_client: &reqwest::Client,
+    ) -> Result<MemberChallenge, Error> {
+        let pool_url = &self.pool_url.clone().ok_or(Error::Internal(
+            "must specify the pool url flag".to_string(),
+        ))?;
+        let pubkey = self.signer().pubkey();
+        let get_url = format!("{}/{}", pool_url, pubkey);
+        let resp = http_client.get(get_url).send().await?;
+        resp.json::<MemberChallenge>().await.map_err(From::from)
+    }
+
+    pub async fn post_pool_solution(
+        &self,
+        http_client: &reqwest::Client,
+        solution: &Solution,
+    ) -> Result<(), Error> {
+        let pool_url = &self.pool_url.clone().ok_or(Error::Internal(
+            "must specify the pool url flag".to_string(),
+        ))?;
+        let pubkey = self.signer().pubkey();
+        let signature = self.sign_solution(solution);
+        let payload = ContributePayload {
+            authority: pubkey,
+            solution: *solution,
+            signature,
+        };
+        http_client.post(pool_url).json(&payload).send().await?;
+        Ok(())
+    }
+
+    fn sign_solution(&self, solution: &Solution) -> Signature {
+        let keypair = &self.signer();
+        keypair.sign_message(solution.to_bytes().as_slice())
+    }
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -11,7 +11,7 @@ impl Miner {
         last_hash_at: i64,
     ) -> Result<MemberChallenge, Error> {
         let mut retries = 0;
-        let max_retries = 10;
+        let max_retries = 12; // 60 seconds, should yield new challenge
         loop {
             let challenge = self.get_pool_challenge(http_client).await?;
             println!("fetched: {:?}", challenge.challenge.lash_hash_at);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -5,6 +5,7 @@ use solana_sdk::{signature::Signature, signer::Signer};
 use crate::{error::Error, Miner};
 
 impl Miner {
+    // TODO: build and sign tx here
     pub async fn post_pool_register(&self, http_client: &reqwest::Client) -> Result<Member, Error> {
         let pool_url = &self.pool_url.clone().ok_or(Error::Internal(
             "must specify the pool url flag".to_string(),

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -11,7 +11,7 @@ impl Miner {
         last_hash_at: i64,
     ) -> Result<MemberChallenge, Error> {
         let mut retries = 0;
-        let max_retries = 12; // 60 seconds, should yield new challenge
+        let max_retries = 24; // 120 seconds, should yield new challenge
         loop {
             let challenge = self.get_pool_challenge(http_client).await?;
             println!("fetched: {:?}", challenge.challenge.lash_hash_at);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -67,8 +67,7 @@ impl Miner {
         let pool_url = &self.pool_url.clone().ok_or(Error::Internal(
             "must specify the pool url flag".to_string(),
         ))?;
-        let pubkey = self.signer().pubkey();
-        let get_url = format!("{}/challenge/{}", pool_url, pubkey);
+        let get_url = format!("{}/challenge", pool_url);
         let resp = http_client.get(get_url).send().await?;
         resp.json::<MemberChallenge>().await.map_err(From::from)
     }


### PR DESCRIPTION
# Integration with the Mining Pools interface / protocol.

Clients here can specify the `--pool-url` to the `mine` and `claim` instructions.

With the `mine` command, solutions are forward to the specified mining pool.
With the `claim` command, ORE can be claimed from the respective pool-member account.

## TODOs:
The `ore-pool-api` dependency could be published to [crates.io](https://crates.io).
Still need to implement the `close` instruction via a `--pool-url`.
Pool-member registration should be signed for and paid here by the CLI keypair. Right now the pool operator is paying for that transaction.