### PR TITLE
fix install and build failures due to boost-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "2.1.9"
+version = "2.2.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "ore-boost-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ indicatif = "0.17.8"
 mpl-token-metadata = "4.1.2"
 num_cpus = "1.16.0"
 ore-api = "2.1.9"
-ore-boost-api = "0.1.0"
+ore-boost-api = "0.2.0"
 ore-pool-api = { path = "../ore-pool/api" }
 ore-pool-types = { path = "../ore-pool/types", package = "types" }
 url = "2.5"


### PR DESCRIPTION
when trying to install the latest version of the ore-cli via cargo (v2.3.2) or building from source, `Boost::try_from_bytes` errors due to locating the `AccountDeserialize`

error being received:
```
no function or associated item named `try_from_bytes` found for struct `ore_boost_api::state::Boost` in the current scope
items from traits can only be used if the trait is in scoperustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B0%5D?0#file%3A%2F%2F%2Fhome%2Fnick%2Fcode%2Fore%2Fore-cli%2Fsrc%2Futils.rs)
utils.rs(1, 1): the following trait is implemented but not in scope; perhaps add a `use` for it:: `use ore_utils::traits::AccountDeserialize;
```

updating the boost-api crates fixes since it has the latest updates