### PR TITLE
Display retry amount when fetching new challenge from pool

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -142,7 +142,7 @@ impl Pool {
         let max_retries = 24; // 120 seconds, should yield new challenge
         let progress_bar = Arc::new(spinner::new_progress_bar());
         loop {
-            progress_bar.set_message("Fetching new challenge...");
+            progress_bar.set_message(format!("Fetching new challenge... (retry {})", retries));
             let challenge = self.get_pool_challenge().await?;
             if challenge.challenge.lash_hash_at == last_hash_at {
                 retries += 1;


### PR DESCRIPTION
I'm mining with the official Ec1ipse pool and noticing that a lot of time is wasted on fetching a new challenge. This should make it easier for the user to understand that it isn't just hanging.
