### PR TITLE
Multiple Devices Same Keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,9 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "ore-api"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dd8451eeb0592e30a3c59c7b4721e73b40a80bb749e9d993abadf29fb12099"
+version = "2.7.0"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2773,8 +2771,6 @@ dependencies = [
 [[package]]
 name = "ore-boost-api"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce6c36c89d829a4b36debc127625513aaf668ed8f0eb4982493fdc3b6b004e9"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2831,8 +2827,6 @@ dependencies = [
 [[package]]
 name = "ore-pool-api"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a7078c3e8687ef85325c41e5055c420764dcc63cd14f28eae28224144f0ba8"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -2853,8 +2847,6 @@ dependencies = [
 [[package]]
 name = "ore-pool-types"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be700f4e4c030089f7a05e6e0bd9e8a9f8ab62a6f43580bb2bfbe9935a8162a"
 dependencies = [
  "drillx",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.30"
 indicatif = "0.17.8"
 mpl-token-metadata = "4.1.2"
 num_cpus = "1.16.0"
-ore-api = "2.5"
+ore-api = "2.7"
 ore-boost-api = "0.3"
 ore-pool-api = "0.2"
 ore-pool-types = "0.2"
@@ -56,11 +56,11 @@ thiserror = "1.0.63"
 tokio = "1.35.1"
 tokio-tungstenite = "0.16"
 
-## [patch.crates-io]
-## ore-api = { path = "../ore/api" }
-## ore-boost-api = { path = "../ore-boost/api" }
-## ore-pool-api = { path = "../ore-pool/api" }
-## ore-pool-types = { path = "../ore-pool/types" }
+[patch.crates-io]
+ore-api = { path = "../ore/api" }
+ore-boost-api = { path = "../ore-boost/api" }
+ore-pool-api = { path = "../ore-pool/api" }
+ore-pool-types = { path = "../ore-pool/types" }
 
 [profile.release]
 opt-level = 3           # Optimize for binary size. You can use "3" for full optimizations if binary size isn't an issue.

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,6 @@ pub enum Error {
     SolanaProgram(#[from] solana_program::program_error::ProgramError),
     #[error("parse int")]
     ParseInt(#[from] std::num::ParseIntError),
+    #[error("number of devices per keypair exceeded")]
+    TooManyDevices,
 }

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -203,8 +203,12 @@ impl Miner {
             // Build nonce indices
             let num_total_members = member_challenge.num_total_members.max(1);
             let u64_unit = u64::MAX.saturating_div(num_total_members);
-            let left_bound = u64_unit.saturating_mul(nonce_index);
-            let range_per_core = u64_unit.saturating_div(args.cores);
+            // Split member nonce space for multiple devices
+            let nonce_unit = u64_unit.saturating_div(5);
+            let left_bound = u64_unit.saturating_mul(nonce_index)
+                + member_challenge.device_id.saturating_mul(nonce_unit);
+            // Split nonce-device space for muliple cores
+            let range_per_core = nonce_unit.saturating_div(args.cores);
             let mut nonce_indices = Vec::with_capacity(args.cores as usize);
             for n in 0..(args.cores) {
                 let index = left_bound + n * range_per_core;

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -206,10 +206,10 @@ impl Miner {
             // Split member nonce space for multiple devices
             let nonce_unit = u64_unit.saturating_div(member_challenge.num_devices as u64);
             println!("nonce unit: {}", nonce_unit);
-            let device_id = member_challenge
-                .device_id
-                .saturating_sub(1)
-                .min(member_challenge.num_devices) as u64;
+            if member_challenge.device_id.gt(&member_challenge.num_devices) {
+                return Err(Error::TooManyDevices);
+            }
+            let device_id = member_challenge.device_id.saturating_sub(1) as u64;
             println!("device id: {}", device_id);
             let left_bound =
                 u64_unit.saturating_mul(nonce_index) + device_id.saturating_mul(nonce_unit);

--- a/src/mine.rs
+++ b/src/mine.rs
@@ -205,15 +205,12 @@ impl Miner {
             let u64_unit = u64::MAX.saturating_div(num_total_members);
             // Split member nonce space for multiple devices
             let nonce_unit = u64_unit.saturating_div(member_challenge.num_devices as u64);
-            println!("nonce unit: {}", nonce_unit);
             if member_challenge.device_id.gt(&member_challenge.num_devices) {
                 return Err(Error::TooManyDevices);
             }
             let device_id = member_challenge.device_id.saturating_sub(1) as u64;
-            println!("device id: {}", device_id);
             let left_bound =
                 u64_unit.saturating_mul(nonce_index) + device_id.saturating_mul(nonce_unit);
-            println!("left bound: {}", left_bound);
             // Split nonce-device space for muliple cores
             let range_per_core = nonce_unit.saturating_div(args.cores);
             let mut nonce_indices = Vec::with_capacity(args.cores as usize);
@@ -221,7 +218,6 @@ impl Miner {
                 let index = left_bound + n * range_per_core;
                 nonce_indices.push(index);
             }
-            println!("nonce indices: {:?}", nonce_indices);
 
             // Run drillx
             let solution = Self::find_hash_par(

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -141,16 +141,12 @@ impl Pool {
         last_hash_at: i64,
     ) -> Result<MemberChallengeV2, Error> {
         let mut retries = 0;
-        let max_retries = 120; // 120 seconds, should yield new challenge
         let progress_bar = Arc::new(spinner::new_progress_bar());
         loop {
             progress_bar.set_message(format!("Fetching new challenge... (retry {})", retries));
             let challenge = self.get_pool_challenge(miner).await?;
             if challenge.challenge.lash_hash_at == last_hash_at {
                 retries += 1;
-                if retries == max_retries {
-                    return Err(Error::Internal("could not fetch new challenge".to_string()));
-                }
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             } else {
                 progress_bar.finish_with_message("Found new challenge");

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use drillx::Solution;
 use ore_pool_types::{
-    BalanceUpdate, ContributePayload, Member, MemberChallenge, PoolAddress, RegisterPayload,
+    BalanceUpdate, ContributePayload, Member, MemberChallengeV2, PoolAddress, RegisterPayload,
     RegisterStakerPayload, Staker, UpdateBalancePayload,
 };
 use solana_rpc_client::spinner;
@@ -137,14 +137,15 @@ impl Pool {
 
     pub async fn get_updated_pool_challenge(
         &self,
+        miner: &Miner,
         last_hash_at: i64,
-    ) -> Result<MemberChallenge, Error> {
+    ) -> Result<MemberChallengeV2, Error> {
         let mut retries = 0;
         let max_retries = 120; // 120 seconds, should yield new challenge
         let progress_bar = Arc::new(spinner::new_progress_bar());
         loop {
             progress_bar.set_message(format!("Fetching new challenge... (retry {})", retries));
-            let challenge = self.get_pool_challenge().await?;
+            let challenge = self.get_pool_challenge(miner).await?;
             if challenge.challenge.lash_hash_at == last_hash_at {
                 retries += 1;
                 if retries == max_retries {
@@ -211,15 +212,16 @@ impl Pool {
         }
     }
 
-    async fn get_pool_challenge(&self) -> Result<MemberChallenge, Error> {
-        let get_url = format!("{}/challenge", self.pool_url);
+    async fn get_pool_challenge(&self, miner: &Miner) -> Result<MemberChallengeV2, Error> {
+        let pubkey = miner.signer().pubkey();
+        let get_url = format!("{}/challenge/{}", self.pool_url, pubkey);
         let resp = self.http_client.get(get_url).send().await?;
         match resp.error_for_status() {
             Err(err) => {
                 println!("{:?}", err);
                 Err(err).map_err(From::from)
             }
-            Ok(resp) => resp.json::<MemberChallenge>().await.map_err(From::from),
+            Ok(resp) => resp.json::<MemberChallengeV2>().await.map_err(From::from),
         }
     }
 

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -294,8 +294,7 @@ impl Miner {
         let stake_data = self.rpc_client.get_account_data(&stake_address).await?;
         let _ = Stake::try_from_bytes(stake_data.as_slice())?;
         // open share account, if needed
-        let staker = pool.post_pool_register_staker(self, &mint).await?;
-        println!("{:?}", staker);
+        let _ = pool.post_pool_register_staker(self, &mint).await?;
         // send tx
         let ix =
             ore_pool_api::sdk::stake(signer.pubkey(), mint, pool_address.address, sender, amount);

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -294,7 +294,8 @@ impl Miner {
         let stake_data = self.rpc_client.get_account_data(&stake_address).await?;
         let _ = Stake::try_from_bytes(stake_data.as_slice())?;
         // open share account, if needed
-        let _ = pool.post_pool_register_staker(self, &mint).await?;
+        let staker = pool.post_pool_register_staker(self, &mint).await?;
+        println!("{:?}", staker);
         // send tx
         let ix =
             ore_pool_api::sdk::stake(signer.pubkey(), mint, pool_address.address, sender, amount);


### PR DESCRIPTION
Mining from multiple devices with the same keypair.

This implementation divides the client's nonce-space by the maximum number of devices permitted per client, as dictated by the pool server.

From the perspective of the server, these multiple devices just look like more continuous submissions.

We require here bumping the `ore-pool-types` crate after a minor release, which will give us the new member challenge v2 type.
Backwards compatibility is maintained on the server for clients that don't upgrade.  