### PR TITLE
Manual device ID assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3064,9 +3064,9 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-api"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb11c2bdb05e15d5979a72412f8b401a319c17882208443de1c2f5ce6867e228"
+checksum = "58f13ce056c99da3e72def474a949bc832dd76dab1b4d6e44bde5ee4b69b17c9"
 dependencies = [
  "array-const-fn-init",
  "bytemuck",
@@ -3087,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "ore-pool-types"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f1de67ae752889cf9440be9dda3a23e582a00d90b7023cb4c4d15c3fc0fd10"
+checksum = "177c92cfed530fbbfdb666b157558338e5a0f30476a1e90715999cccd7f55ba3"
 dependencies = [
  "drillx",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "ore-cli"
-version = "3.0.2"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "b64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ore-cli"
-version = "3.0.2"
+version = "3.1.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A command line interface for ORE cryptocurrency mining."
@@ -38,8 +38,8 @@ num_cpus = "1.16.0"
 ore-api = "3.0"
 ore-boost-api = "1.1"
 ore-boost-legacy-api = { version = "0.3", package = "ore-boost-api" }
-ore-pool-api = "1.1"
-ore-pool-types = "1.1"
+ore-pool-api = "1.2"
+ore-pool-types = "1.2"
 url = "2.5"
 rand = "0.8.4"
 reqwest = { version = "0.12", features = ["json"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -133,6 +133,14 @@ pub struct MineArgs {
     #[arg(
         long,
         short,
+        value_name = "DEVICE_ID",
+        help = "An optional device id to use for pool mining (max 5 devices per keypair)."
+    )]
+    pub device_id: Option<u64>,
+
+    #[arg(
+        long,
+        short,
         value_name = "POOL_URL",
         help = "The optional pool url to join and forward solutions to."
     )]

--- a/src/command/mine.rs
+++ b/src/command/mine.rs
@@ -168,6 +168,9 @@ impl Miner {
         let pool_member = pool.post_pool_register(self).await?;
         let nonce_index = pool_member.id as u64;
 
+        // Get device id
+        let device_id = args.device_id.unwrap_or(0);
+
         // Check num threads
         self.check_num_cores(args.cores);
 
@@ -211,11 +214,12 @@ impl Miner {
             let member_search_space_size = u64::MAX.saturating_div(num_total_members);
             let device_search_space_size = member_search_space_size.saturating_div(member_challenge.num_devices as u64);
 
-            // Calculate bounds on 
-            if member_challenge.device_id.gt(&member_challenge.num_devices) {
+            // Check device id doesn't go beyond pool limit
+            if (device_id as u8) > member_challenge.num_devices {
                 return Err(Error::TooManyDevices);
             }
-            let device_id = member_challenge.device_id.saturating_sub(1) as u64;
+
+            // Calculate bounds on nonce space
             let left_bound =
                 member_search_space_size.saturating_mul(nonce_index) + device_id.saturating_mul(device_search_space_size);
 


### PR DESCRIPTION
Automated device ID assignment is creating too many edge cases in pool-client communication. This change deprecates the process by which pool servers would automatically assign a device ID in favor of a system where the user manually sets the device ID on the client.