### PR TITLE
Fix: Update ore-pool-api to 1.3 to remove bump requirement in claim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ num_cpus = "1.16.0"
 ore-api = "3.0"
 ore-boost-api = "1.1"
 ore-boost-legacy-api = { version = "0.3", package = "ore-boost-api" }
-ore-pool-api = "1.2"
+ore-pool-api = "1.3"
 ore-pool-types = "1.2"
 url = "2.5"
 rand = "0.8.4"

--- a/src/command/claim.rs
+++ b/src/command/claim.rs
@@ -160,7 +160,6 @@ impl Miner {
             self.signer().pubkey(),
             beneficiary,
             pool_address.address,
-            pool_address.bump,
             amount,
         ));
         self.send_and_confirm(&ixs, ComputeBudget::Fixed(50_000), false)


### PR DESCRIPTION
Steel v2 no removes requirement for bumps